### PR TITLE
Remove unused twisted code

### DIFF
--- a/relapse/app/_base.py
+++ b/relapse/app/_base.py
@@ -20,12 +20,10 @@ import signal
 import socket
 import sys
 import traceback
-import warnings
 from collections.abc import Awaitable
 from textwrap import indent
 from typing import TYPE_CHECKING, Any, Callable, NoReturn, Optional, cast
 
-from cryptography.utils import CryptographyDeprecationWarning
 from typing_extensions import ParamSpec
 
 import twisted
@@ -302,15 +300,6 @@ def listen_manhole(
     manhole_settings: ManholeConfig,
     manhole_globals: dict,
 ) -> None:
-    # twisted.conch.manhole 21.1.0 uses "int_from_bytes", which produces a confusing
-    # warning. It's fixed by https://github.com/twisted/twisted/pull/1522), so
-    # suppress the warning for now.
-    warnings.filterwarnings(
-        action="ignore",
-        category=CryptographyDeprecationWarning,
-        message="int_from_bytes is deprecated",
-    )
-
     from relapse.util.manhole import manhole
 
     listen_tcp(

--- a/relapse/util/ratelimitutils.py
+++ b/relapse/util/ratelimitutils.py
@@ -234,9 +234,7 @@ class _PerHostRatelimiter:
         self.host = host
 
         request_id = object()
-        # Ideally we'd use `Deferred.fromCoroutine()` here, to save on redundant
-        # type-checking, but we'd need Twisted >= 21.2.
-        ret = defer.ensureDeferred(self._on_enter_with_tracing(request_id))
+        ret = defer.Deferred.fromCoroutine(self._on_enter_with_tracing(request_id))
         try:
             yield ret
         finally:

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -16,7 +16,7 @@ from unittest.mock import AsyncMock, Mock
 
 import pymacaroons
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.auth.internal import InternalAuth
 from relapse.api.auth_blocking import AuthBlocking

--- a/tests/api/test_filtering.py
+++ b/tests/api/test_filtering.py
@@ -18,7 +18,7 @@ from unittest.mock import patch
 
 import jsonschema
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EduTypes, EventContentFields
 from relapse.api.errors import RelapseError

--- a/tests/app/test_openid_listener.py
+++ b/tests/app/test_openid_listener.py
@@ -15,7 +15,7 @@ from unittest.mock import Mock, patch
 
 from parameterized import parameterized
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.app.generic_worker import GenericWorkerServer
 from relapse.app.homeserver import RelapseHomeServer

--- a/tests/appservice/test_api.py
+++ b/tests/appservice/test_api.py
@@ -15,7 +15,7 @@ from collections.abc import Mapping, Sequence
 from typing import Any, Optional, Union
 from unittest.mock import Mock
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.appservice import ApplicationService
 from relapse.server import HomeServer

--- a/tests/appservice/test_scheduler.py
+++ b/tests/appservice/test_scheduler.py
@@ -18,7 +18,7 @@ from unittest.mock import AsyncMock, Mock
 from typing_extensions import TypeAlias
 
 from twisted.internet import defer
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.appservice import (
     ApplicationService,

--- a/tests/crypto/test_keyring.py
+++ b/tests/crypto/test_keyring.py
@@ -24,7 +24,7 @@ from signedjson.types import SigningKey, VerifyKey
 
 from twisted.internet import defer
 from twisted.internet.defer import Deferred, ensureDeferred
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.errors import RelapseError
 from relapse.crypto import keyring

--- a/tests/events/test_presence_router.py
+++ b/tests/events/test_presence_router.py
@@ -17,7 +17,7 @@ from unittest.mock import AsyncMock, Mock
 
 import attr
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EduTypes
 from relapse.events.presence_router import PresenceRouter

--- a/tests/events/test_snapshot.py
+++ b/tests/events/test_snapshot.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.events import EventBase
 from relapse.events.snapshot import EventContext

--- a/tests/federation/test_federation_catch_up.py
+++ b/tests/federation/test_federation_catch_up.py
@@ -3,7 +3,7 @@ from typing import Callable, Optional
 from unittest import mock
 from unittest.mock import AsyncMock, Mock
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EventTypes
 from relapse.events import EventBase

--- a/tests/federation/test_federation_client.py
+++ b/tests/federation/test_federation_client.py
@@ -16,7 +16,7 @@ from unittest import mock
 
 import twisted.web.client
 from twisted.internet import defer
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.room_versions import RoomVersions
 from relapse.events import EventBase

--- a/tests/federation/test_federation_sender.py
+++ b/tests/federation/test_federation_sender.py
@@ -18,7 +18,7 @@ from signedjson import key, sign
 from signedjson.types import BaseKey, SigningKey
 
 from twisted.internet import defer
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EduTypes, RoomEncryptionAlgorithms
 from relapse.federation.units import Transaction

--- a/tests/federation/test_federation_server.py
+++ b/tests/federation/test_federation_server.py
@@ -17,7 +17,7 @@ from http import HTTPStatus
 
 from parameterized import parameterized
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.room_versions import KNOWN_ROOM_VERSIONS
 from relapse.config.server import DEFAULT_ROOM_VERSION

--- a/tests/federation/transport/test_knocking.py
+++ b/tests/federation/transport/test_knocking.py
@@ -14,7 +14,7 @@
 from collections import OrderedDict
 from typing import Any, Optional
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EventTypes, JoinRules, Membership
 from relapse.api.room_versions import RoomVersion, RoomVersions

--- a/tests/handlers/test_admin.py
+++ b/tests/handlers/test_admin.py
@@ -15,7 +15,7 @@
 from collections import Counter
 from unittest.mock import Mock
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EventTypes, JoinRules
 from relapse.api.room_versions import RoomVersions

--- a/tests/handlers/test_appservice.py
+++ b/tests/handlers/test_appservice.py
@@ -19,7 +19,7 @@ from unittest.mock import AsyncMock, Mock
 from parameterized import parameterized
 
 from twisted.internet import defer
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EduTypes, EventTypes
 from relapse.appservice import (

--- a/tests/handlers/test_auth.py
+++ b/tests/handlers/test_auth.py
@@ -16,7 +16,7 @@ from unittest.mock import AsyncMock
 
 import pymacaroons
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.errors import AuthError, ResourceLimitError
 from relapse.rest import admin

--- a/tests/handlers/test_cas.py
+++ b/tests/handlers/test_cas.py
@@ -14,7 +14,7 @@
 from typing import Any
 from unittest.mock import AsyncMock, Mock
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.handlers.cas import CasResponse
 from relapse.server import HomeServer

--- a/tests/handlers/test_deactivate_account.py
+++ b/tests/handlers/test_deactivate_account.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import AccountDataTypes
 from relapse.push.rulekinds import PRIORITY_CLASS_MAP

--- a/tests/handlers/test_device.py
+++ b/tests/handlers/test_device.py
@@ -18,7 +18,7 @@ from typing import Optional
 from unittest import mock
 
 from twisted.internet.defer import ensureDeferred
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import RoomEncryptionAlgorithms
 from relapse.api.errors import NotFoundError, RelapseError

--- a/tests/handlers/test_directory.py
+++ b/tests/handlers/test_directory.py
@@ -16,7 +16,7 @@ from collections.abc import Awaitable
 from typing import Any, Callable
 from unittest.mock import AsyncMock, Mock
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import relapse.api.errors
 from relapse.api.constants import EventTypes

--- a/tests/handlers/test_e2e_keys.py
+++ b/tests/handlers/test_e2e_keys.py
@@ -19,7 +19,7 @@ from unittest import mock
 from parameterized import parameterized
 from signedjson import key as key, sign as sign
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import RoomEncryptionAlgorithms
 from relapse.api.errors import Codes, RelapseError

--- a/tests/handlers/test_e2e_room_keys.py
+++ b/tests/handlers/test_e2e_room_keys.py
@@ -17,7 +17,7 @@
 import copy
 from unittest import mock
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.errors import RelapseError
 from relapse.server import HomeServer

--- a/tests/handlers/test_federation.py
+++ b/tests/handlers/test_federation.py
@@ -18,7 +18,7 @@ from unittest import TestCase
 from unittest.mock import AsyncMock, Mock, patch
 
 from twisted.internet.defer import Deferred
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EventTypes
 from relapse.api.errors import (

--- a/tests/handlers/test_federation_event.py
+++ b/tests/handlers/test_federation_event.py
@@ -14,7 +14,7 @@
 from typing import Optional
 from unittest import mock
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.errors import AuthError, StoreError
 from relapse.api.room_versions import RoomVersion

--- a/tests/handlers/test_message.py
+++ b/tests/handlers/test_message.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import logging
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EventTypes
 from relapse.events import EventBase

--- a/tests/handlers/test_oauth_delegation.py
+++ b/tests/handlers/test_oauth_delegation.py
@@ -25,7 +25,7 @@ from signedjson.key import (
 )
 from signedjson.sign import sign_json
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 from twisted.web.http_headers import Headers
 from twisted.web.iweb import IResponse
 

--- a/tests/handlers/test_oidc.py
+++ b/tests/handlers/test_oidc.py
@@ -19,7 +19,7 @@ from urllib.parse import parse_qs, urlparse
 
 import pymacaroons
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.handlers.sso import MappingException
 from relapse.http.site import RelapseRequest

--- a/tests/handlers/test_password_providers.py
+++ b/tests/handlers/test_password_providers.py
@@ -18,7 +18,7 @@ from http import HTTPStatus
 from typing import Any, Optional, Union
 from unittest.mock import AsyncMock, Mock
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import LoginType
 from relapse.api.errors import Codes

--- a/tests/handlers/test_presence.py
+++ b/tests/handlers/test_presence.py
@@ -18,7 +18,7 @@ from unittest.mock import Mock, call
 from parameterized import parameterized
 from signedjson.key import generate_signing_key
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EventTypes, Membership, PresenceState
 from relapse.api.presence import UserDevicePresenceState, UserPresenceState

--- a/tests/handlers/test_profile.py
+++ b/tests/handlers/test_profile.py
@@ -17,7 +17,7 @@ from unittest.mock import AsyncMock, Mock
 
 from parameterized import parameterized
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import relapse.types
 from relapse.api.errors import AuthError, RelapseError

--- a/tests/handlers/test_receipts.py
+++ b/tests/handlers/test_receipts.py
@@ -14,7 +14,7 @@
 
 from copy import deepcopy
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EduTypes, ReceiptTypes
 from relapse.server import HomeServer

--- a/tests/handlers/test_register.py
+++ b/tests/handlers/test_register.py
@@ -16,7 +16,7 @@ from collections.abc import Collection
 from typing import Any, Optional
 from unittest.mock import AsyncMock, Mock
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.auth.internal import InternalAuth
 from relapse.api.constants import UserTypes

--- a/tests/handlers/test_room_member.py
+++ b/tests/handlers/test_room_member.py
@@ -1,6 +1,6 @@
 from unittest.mock import AsyncMock, patch
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import relapse.rest.client.login
 import relapse.rest.client.room

--- a/tests/handlers/test_room_summary.py
+++ b/tests/handlers/test_room_summary.py
@@ -16,7 +16,7 @@ from typing import Any, Optional
 from unittest import mock
 
 from twisted.internet.defer import ensureDeferred
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import (
     EventContentFields,

--- a/tests/handlers/test_saml.py
+++ b/tests/handlers/test_saml.py
@@ -17,7 +17,7 @@ from unittest.mock import AsyncMock, Mock
 
 import attr
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.errors import RedirectException
 from relapse.module_api import ModuleApi

--- a/tests/handlers/test_sso.py
+++ b/tests/handlers/test_sso.py
@@ -13,7 +13,7 @@ from http import HTTPStatus
 from typing import BinaryIO, Callable, Optional
 from unittest.mock import Mock
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 from twisted.web.http_headers import Headers
 
 from relapse.api.errors import Codes, RelapseError

--- a/tests/handlers/test_stats.py
+++ b/tests/handlers/test_stats.py
@@ -14,7 +14,7 @@
 
 from typing import Any, Optional, cast
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.rest import admin
 from relapse.rest.client import login, room

--- a/tests/handlers/test_sync.py
+++ b/tests/handlers/test_sync.py
@@ -14,7 +14,7 @@
 from typing import Optional
 from unittest.mock import AsyncMock, Mock, patch
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EventTypes, JoinRules
 from relapse.api.errors import Codes, ResourceLimitError

--- a/tests/handlers/test_typing.py
+++ b/tests/handlers/test_typing.py
@@ -18,7 +18,7 @@ from unittest.mock import ANY, AsyncMock, Mock, call
 
 from netaddr import IPSet
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 from twisted.web.resource import Resource
 
 from relapse.api.constants import EduTypes

--- a/tests/handlers/test_user_directory.py
+++ b/tests/handlers/test_user_directory.py
@@ -15,7 +15,7 @@ from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 from urllib.parse import quote
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import UserTypes
 from relapse.api.errors import RelapseError

--- a/tests/handlers/test_worker_lock.py
+++ b/tests/handlers/test_worker_lock.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from twisted.internet import defer
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.server import HomeServer
 from relapse.util import Clock

--- a/tests/http/server/_base.py
+++ b/tests/http/server/_base.py
@@ -23,8 +23,8 @@ from incremental import Version
 from twisted import version
 from twisted.internet.defer import Deferred
 from twisted.internet.error import ConnectionDone
+from twisted.internet.testing import MemoryReactorClock
 from twisted.python.failure import Failure
-from twisted.test.proto_helpers import MemoryReactorClock
 from twisted.web.server import Site
 
 from relapse.http.server import (

--- a/tests/http/test_client.py
+++ b/tests/http/test_client.py
@@ -20,8 +20,8 @@ from netaddr import IPSet
 
 from twisted.internet.defer import Deferred
 from twisted.internet.error import DNSLookupError
+from twisted.internet.testing import AccumulatingProtocol
 from twisted.python.failure import Failure
-from twisted.test.proto_helpers import AccumulatingProtocol
 from twisted.web.client import Agent, ResponseDone
 from twisted.web.iweb import UNKNOWN_LENGTH
 

--- a/tests/http/test_matrixfederationclient.py
+++ b/tests/http/test_matrixfederationclient.py
@@ -21,7 +21,7 @@ from parameterized import parameterized
 from twisted.internet import defer
 from twisted.internet.defer import Deferred, TimeoutError
 from twisted.internet.error import ConnectingCancelledError, DNSLookupError
-from twisted.test.proto_helpers import MemoryReactor, StringTransport
+from twisted.internet.testing import MemoryReactor, StringTransport
 from twisted.web.client import Agent, ResponseNeverReceived
 from twisted.web.http import HTTPChannel
 from twisted.web.http_headers import Headers

--- a/tests/http/test_simple_client.py
+++ b/tests/http/test_simple_client.py
@@ -17,7 +17,7 @@ from netaddr import IPSet
 
 from twisted.internet import defer
 from twisted.internet.error import DNSLookupError
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.http import RequestTimedOutError
 from relapse.http.client import SimpleHttpClient

--- a/tests/http/test_site.py
+++ b/tests/http/test_site.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from twisted.internet.address import IPv6Address
-from twisted.test.proto_helpers import MemoryReactor, StringTransport
+from twisted.internet.testing import MemoryReactor, StringTransport
 
 from relapse.app.homeserver import RelapseHomeServer
 from relapse.server import HomeServer

--- a/tests/logging/test_opentracing.py
+++ b/tests/logging/test_opentracing.py
@@ -16,7 +16,7 @@ from collections.abc import Awaitable
 from typing import cast
 
 from twisted.internet import defer
-from twisted.test.proto_helpers import MemoryReactorClock
+from twisted.internet.testing import MemoryReactorClock
 
 from relapse.logging.context import (
     LoggingContext,

--- a/tests/media/test_media_retention.py
+++ b/tests/media/test_media_retention.py
@@ -18,7 +18,7 @@ from typing import Optional
 
 from matrix_common.types.mxc_uri import MXCUri
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.rest import admin
 from relapse.rest.client import login, register, room

--- a/tests/media/test_media_storage.py
+++ b/tests/media/test_media_storage.py
@@ -27,8 +27,8 @@ from typing_extensions import Literal
 
 from twisted.internet import defer
 from twisted.internet.defer import Deferred
+from twisted.internet.testing import MemoryReactor
 from twisted.python.failure import Failure
-from twisted.test.proto_helpers import MemoryReactor
 from twisted.web.resource import Resource
 
 from relapse.api.errors import Codes, HttpResponseException

--- a/tests/media/test_oembed.py
+++ b/tests/media/test_oembed.py
@@ -17,7 +17,7 @@ from typing import Any
 
 from parameterized import parameterized
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.media.oembed import OEmbedProvider, OEmbedResult
 from relapse.server import HomeServer

--- a/tests/media/test_url_previewer.py
+++ b/tests/media/test_url_previewer.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import os
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.server import HomeServer
 from relapse.util import Clock

--- a/tests/module_api/test_account_data_manager.py
+++ b/tests/module_api/test_account_data_manager.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.errors import RelapseError
 from relapse.rest import admin

--- a/tests/module_api/test_api.py
+++ b/tests/module_api/test_api.py
@@ -15,7 +15,7 @@ from typing import Any, Optional
 from unittest.mock import AsyncMock, Mock
 
 from twisted.internet import defer
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EduTypes, EventTypes
 from relapse.api.errors import NotFoundError

--- a/tests/module_api/test_event_unsigned_addition.py
+++ b/tests/module_api/test_event_unsigned_addition.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.events import EventBase
 from relapse.rest import admin, login, room

--- a/tests/push/test_bulk_push_rule_evaluator.py
+++ b/tests/push/test_bulk_push_rule_evaluator.py
@@ -17,7 +17,7 @@ from unittest.mock import AsyncMock, patch
 
 from parameterized import parameterized
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EventContentFields, RelationTypes
 from relapse.api.room_versions import RoomVersions

--- a/tests/push/test_email.py
+++ b/tests/push/test_email.py
@@ -22,7 +22,7 @@ import attr
 from parameterized import parameterized
 
 from twisted.internet.defer import Deferred
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.errors import Codes, RelapseError
 from relapse.push.emailpusher import EmailPusher

--- a/tests/push/test_http.py
+++ b/tests/push/test_http.py
@@ -15,7 +15,7 @@ from typing import Any
 from unittest.mock import Mock
 
 from twisted.internet.defer import Deferred
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.logging.context import make_deferred_yieldable
 from relapse.push import PusherConfig, PusherConfigException

--- a/tests/push/test_push_rule_evaluator.py
+++ b/tests/push/test_push_rule_evaluator.py
@@ -14,7 +14,7 @@
 
 from typing import Any, Optional, Union, cast
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EventTypes, HistoryVisibility, Membership
 from relapse.api.room_versions import RoomVersions

--- a/tests/replication/_base.py
+++ b/tests/replication/_base.py
@@ -17,8 +17,8 @@ from typing import Any, Optional
 
 from twisted.internet.address import IPv4Address
 from twisted.internet.protocol import Protocol, connectionDone
+from twisted.internet.testing import MemoryReactor
 from twisted.python.failure import Failure
-from twisted.test.proto_helpers import MemoryReactor
 from twisted.web.resource import Resource
 
 from relapse.app.generic_worker import GenericWorkerServer

--- a/tests/replication/storage/_base.py
+++ b/tests/replication/storage/_base.py
@@ -17,7 +17,7 @@ from collections.abc import Iterable
 from typing import Any, Callable, Optional
 from unittest.mock import Mock
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.server import HomeServer
 from relapse.util import Clock

--- a/tests/replication/storage/test_events.py
+++ b/tests/replication/storage/test_events.py
@@ -18,7 +18,7 @@ from typing import Any, Optional
 from canonicaljson import encode_canonical_json
 from parameterized import parameterized
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import ReceiptTypes
 from relapse.api.room_versions import RoomVersions

--- a/tests/replication/tcp/streams/test_events.py
+++ b/tests/replication/tcp/streams/test_events.py
@@ -16,7 +16,7 @@ from typing import Any, Optional
 
 from parameterized import parameterized
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EventTypes, Membership
 from relapse.events import EventBase

--- a/tests/replication/test_auth.py
+++ b/tests/replication/test_auth.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import logging
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.rest.client import register
 from relapse.server import HomeServer

--- a/tests/replication/test_federation_ack.py
+++ b/tests/replication/test_federation_ack.py
@@ -14,7 +14,7 @@
 
 from unittest import mock
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.app.generic_worker import GenericWorkerServer
 from relapse.replication.tcp.commands import FederationAckCommand

--- a/tests/replication/test_multi_media_repo.py
+++ b/tests/replication/test_multi_media_repo.py
@@ -16,7 +16,7 @@ import os
 from typing import Any, Optional
 
 from twisted.internet.protocol import Factory
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 from twisted.web.http import HTTPChannel
 from twisted.web.server import Request
 

--- a/tests/replication/test_pusher_shard.py
+++ b/tests/replication/test_pusher_shard.py
@@ -15,7 +15,7 @@ import logging
 from unittest.mock import Mock
 
 from twisted.internet import defer
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.rest import admin
 from relapse.rest.client import login, room

--- a/tests/replication/test_sharded_event_persister.py
+++ b/tests/replication/test_sharded_event_persister.py
@@ -14,7 +14,7 @@
 import logging
 from unittest.mock import patch
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.rest import admin
 from relapse.rest.client import login, room, sync

--- a/tests/replication/test_sharded_receipts.py
+++ b/tests/replication/test_sharded_receipts.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import logging
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import ReceiptTypes
 from relapse.rest import admin

--- a/tests/rest/admin/test_admin.py
+++ b/tests/rest/admin/test_admin.py
@@ -16,7 +16,7 @@ import urllib.parse
 
 from parameterized import parameterized
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 from twisted.web.resource import Resource
 
 from relapse.http.server import JsonResource

--- a/tests/rest/admin/test_background_updates.py
+++ b/tests/rest/admin/test_background_updates.py
@@ -15,7 +15,7 @@ from collections.abc import Collection
 
 from parameterized import parameterized
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.errors import Codes
 from relapse.rest import admin

--- a/tests/rest/admin/test_device.py
+++ b/tests/rest/admin/test_device.py
@@ -15,7 +15,7 @@ import urllib.parse
 
 from parameterized import parameterized
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.errors import Codes
 from relapse.handlers.device import MAX_DEVICE_DISPLAY_NAME_LEN, DeviceHandler

--- a/tests/rest/admin/test_event_reports.py
+++ b/tests/rest/admin/test_event_reports.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.errors import Codes
 from relapse.rest import admin

--- a/tests/rest/admin/test_federation.py
+++ b/tests/rest/admin/test_federation.py
@@ -15,7 +15,7 @@ from typing import Optional
 
 from parameterized import parameterized
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.errors import Codes
 from relapse.rest import admin

--- a/tests/rest/admin/test_media.py
+++ b/tests/rest/admin/test_media.py
@@ -16,7 +16,7 @@ import os
 
 from parameterized import parameterized
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 from twisted.web.resource import Resource
 
 from relapse.api.errors import Codes

--- a/tests/rest/admin/test_registration_tokens.py
+++ b/tests/rest/admin/test_registration_tokens.py
@@ -15,7 +15,7 @@ import random
 import string
 from typing import Optional
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.errors import Codes
 from relapse.rest import admin

--- a/tests/rest/admin/test_room.py
+++ b/tests/rest/admin/test_room.py
@@ -20,7 +20,7 @@ from unittest.mock import AsyncMock, Mock
 from parameterized import parameterized
 
 from twisted.internet.task import deferLater
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EventTypes, Membership, RoomTypes
 from relapse.api.errors import Codes

--- a/tests/rest/admin/test_server_notice.py
+++ b/tests/rest/admin/test_server_notice.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from collections.abc import Sequence
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.errors import Codes
 from relapse.rest import admin

--- a/tests/rest/admin/test_statistics.py
+++ b/tests/rest/admin/test_statistics.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 from typing import Optional
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 from twisted.web.resource import Resource
 
 from relapse.api.errors import Codes

--- a/tests/rest/admin/test_user.py
+++ b/tests/rest/admin/test_user.py
@@ -22,7 +22,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 from parameterized import parameterized
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 from twisted.web.resource import Resource
 
 from relapse.api.constants import ApprovalNoticeMedium, LoginType, UserTypes

--- a/tests/rest/admin/test_username_available.py
+++ b/tests/rest/admin/test_username_available.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from typing import Optional
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.errors import Codes, RelapseError
 from relapse.rest import admin

--- a/tests/rest/client/test_account.py
+++ b/tests/rest/client/test_account.py
@@ -19,7 +19,7 @@ from typing import Any, Optional, Union
 from unittest.mock import Mock
 
 from twisted.internet.interfaces import IReactorTCP
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import LoginType, Membership
 from relapse.api.errors import Codes, HttpResponseException

--- a/tests/rest/client/test_auth.py
+++ b/tests/rest/client/test_auth.py
@@ -17,7 +17,7 @@ from http import HTTPStatus
 from typing import Any, Optional, Union
 
 from twisted.internet.defer import succeed
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 from twisted.web.resource import Resource
 
 from relapse.api.constants import ApprovalNoticeMedium, LoginType

--- a/tests/rest/client/test_capabilities.py
+++ b/tests/rest/client/test_capabilities.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from http import HTTPStatus
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.room_versions import KNOWN_ROOM_VERSIONS
 from relapse.rest import admin

--- a/tests/rest/client/test_consent.py
+++ b/tests/rest/client/test_consent.py
@@ -15,7 +15,7 @@
 import os
 from http import HTTPStatus
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.urls import ConsentURIBuilder
 from relapse.rest import admin

--- a/tests/rest/client/test_devices.py
+++ b/tests/rest/client/test_devices.py
@@ -14,7 +14,7 @@
 from http import HTTPStatus
 
 from twisted.internet.defer import ensureDeferred
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.errors import NotFoundError
 from relapse.rest import admin, devices, room, sync

--- a/tests/rest/client/test_directory.py
+++ b/tests/rest/client/test_directory.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from http import HTTPStatus
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.appservice import ApplicationService
 from relapse.rest import admin

--- a/tests/rest/client/test_ephemeral_message.py
+++ b/tests/rest/client/test_ephemeral_message.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from http import HTTPStatus
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EventContentFields, EventTypes
 from relapse.rest import admin

--- a/tests/rest/client/test_events.py
+++ b/tests/rest/client/test_events.py
@@ -16,7 +16,7 @@
 
 from unittest.mock import Mock
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EduTypes
 from relapse.rest import admin

--- a/tests/rest/client/test_filter.py
+++ b/tests/rest/client/test_filter.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.errors import Codes
 from relapse.rest.client import filter

--- a/tests/rest/client/test_identity.py
+++ b/tests/rest/client/test_identity.py
@@ -14,7 +14,7 @@
 
 from http import HTTPStatus
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.rest import admin
 from relapse.rest.client import login, room

--- a/tests/rest/client/test_login.py
+++ b/tests/rest/client/test_login.py
@@ -21,7 +21,7 @@ from urllib.parse import urlencode
 import pymacaroons
 from typing_extensions import Literal
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 from twisted.web.resource import Resource
 
 from relapse.api.constants import ApprovalNoticeMedium, LoginType

--- a/tests/rest/client/test_login_token_request.py
+++ b/tests/rest/client/test_login_token_request.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.rest import admin
 from relapse.rest.client import login, login_token_request, versions

--- a/tests/rest/client/test_mutual_rooms.py
+++ b/tests/rest/client/test_mutual_rooms.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from urllib.parse import quote
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.rest import admin
 from relapse.rest.client import login, mutual_rooms, room

--- a/tests/rest/client/test_notifications.py
+++ b/tests/rest/client/test_notifications.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from unittest.mock import AsyncMock, Mock
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.rest import admin
 from relapse.rest.client import login, notifications, receipts, room

--- a/tests/rest/client/test_password_policy.py
+++ b/tests/rest/client/test_password_policy.py
@@ -14,7 +14,7 @@
 
 from http import HTTPStatus
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import LoginType
 from relapse.api.errors import Codes

--- a/tests/rest/client/test_power_levels.py
+++ b/tests/rest/client/test_power_levels.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from http import HTTPStatus
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.errors import Codes
 from relapse.events.utils import CANONICALJSON_MAX_INT, CANONICALJSON_MIN_INT

--- a/tests/rest/client/test_presence.py
+++ b/tests/rest/client/test_presence.py
@@ -14,7 +14,7 @@
 from http import HTTPStatus
 from unittest.mock import AsyncMock, Mock
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.handlers.presence import PresenceHandler
 from relapse.rest.client import presence

--- a/tests/rest/client/test_profile.py
+++ b/tests/rest/client/test_profile.py
@@ -18,7 +18,7 @@ import urllib.parse
 from http import HTTPStatus
 from typing import Any, Optional
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.errors import Codes
 from relapse.rest import admin

--- a/tests/rest/client/test_read_marker.py
+++ b/tests/rest/client/test_read_marker.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EventTypes
 from relapse.rest import admin

--- a/tests/rest/client/test_receipts.py
+++ b/tests/rest/client/test_receipts.py
@@ -14,7 +14,7 @@
 from http import HTTPStatus
 from typing import Optional
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EduTypes, EventTypes, HistoryVisibility, ReceiptTypes
 from relapse.rest import admin

--- a/tests/rest/client/test_redactions.py
+++ b/tests/rest/client/test_redactions.py
@@ -15,7 +15,7 @@ from typing import Optional
 
 from parameterized import parameterized
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EventTypes, RelationTypes
 from relapse.api.room_versions import RoomVersion, RoomVersions

--- a/tests/rest/client/test_register.py
+++ b/tests/rest/client/test_register.py
@@ -17,7 +17,7 @@ import datetime
 import importlib.resources
 from typing import Any
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import (
     APP_SERVICE_REGISTRATION_TYPE,

--- a/tests/rest/client/test_relations.py
+++ b/tests/rest/client/test_relations.py
@@ -17,7 +17,7 @@ import urllib.parse
 from typing import Any, Callable, Optional
 from unittest.mock import AsyncMock, patch
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import AccountDataTypes, EventTypes, RelationTypes
 from relapse.rest import admin

--- a/tests/rest/client/test_report_event.py
+++ b/tests/rest/client/test_report_event.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.rest import admin
 from relapse.rest.client import login, report_event, room

--- a/tests/rest/client/test_retention.py
+++ b/tests/rest/client/test_retention.py
@@ -14,7 +14,7 @@
 from typing import Any
 from unittest.mock import Mock
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EventTypes
 from relapse.rest import admin

--- a/tests/rest/client/test_rooms.py
+++ b/tests/rest/client/test_rooms.py
@@ -27,7 +27,7 @@ from urllib import parse as urlparse
 from parameterized import param, parameterized
 from typing_extensions import Literal
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse import module_api
 from relapse.api.constants import (

--- a/tests/rest/client/test_shadow_banned.py
+++ b/tests/rest/client/test_shadow_banned.py
@@ -14,7 +14,7 @@
 
 from unittest.mock import Mock, patch
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EduTypes, EventTypes
 from relapse.rest import admin

--- a/tests/rest/client/test_sync.py
+++ b/tests/rest/client/test_sync.py
@@ -16,7 +16,7 @@ import json
 
 from parameterized import parameterized
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import (
     EventContentFields,

--- a/tests/rest/client/test_third_party_rules.py
+++ b/tests/rest/client/test_third_party_rules.py
@@ -14,7 +14,7 @@
 from typing import TYPE_CHECKING, Any, Optional
 from unittest.mock import AsyncMock, Mock
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EventTypes, LoginType, Membership
 from relapse.api.errors import RelapseError

--- a/tests/rest/client/test_typing.py
+++ b/tests/rest/client/test_typing.py
@@ -15,7 +15,7 @@
 
 """Tests REST events for /rooms paths."""
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EduTypes
 from relapse.rest.client import room

--- a/tests/rest/client/test_upgrade_room.py
+++ b/tests/rest/client/test_upgrade_room.py
@@ -14,7 +14,7 @@
 from typing import Optional
 from unittest.mock import patch
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EventContentFields, EventTypes, RoomTypes
 from relapse.config.server import DEFAULT_ROOM_VERSION

--- a/tests/rest/client/test_whois.py
+++ b/tests/rest/client/test_whois.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.errors import Codes
 from relapse.rest import admin

--- a/tests/rest/client/utils.py
+++ b/tests/rest/client/utils.py
@@ -27,7 +27,7 @@ from urllib.parse import urlencode
 import attr
 from typing_extensions import Literal
 
-from twisted.test.proto_helpers import MemoryReactorClock
+from twisted.internet.testing import MemoryReactorClock
 from twisted.web.server import Site
 
 from relapse.api.constants import Membership

--- a/tests/rest/key/v2/test_remote_key_resource.py
+++ b/tests/rest/key/v2/test_remote_key_resource.py
@@ -20,7 +20,7 @@ from canonicaljson import encode_canonical_json
 from signedjson.sign import sign_json
 from signedjson.types import SigningKey
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 from twisted.web.resource import NoResource, Resource
 
 from relapse.crypto.keyring import PerspectivesKeyFetcher

--- a/tests/rest/media/test_domain_blocking.py
+++ b/tests/rest/media/test_domain_blocking.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 from twisted.web.resource import Resource
 
 from relapse.media._base import FileInfo

--- a/tests/rest/media/test_url_preview.py
+++ b/tests/rest/media/test_url_preview.py
@@ -24,7 +24,7 @@ from twisted.internet._resolver import HostResolution
 from twisted.internet.address import IPv4Address, IPv6Address
 from twisted.internet.error import DNSLookupError
 from twisted.internet.interfaces import IAddress, IResolutionReceiver
-from twisted.test.proto_helpers import AccumulatingProtocol, MemoryReactor
+from twisted.internet.testing import AccumulatingProtocol, MemoryReactor
 from twisted.web.resource import Resource
 
 from relapse.config.oembed import OEmbedEndpointConfig

--- a/tests/server.py
+++ b/tests/server.py
@@ -53,9 +53,9 @@ from twisted.internet.interfaces import (
     ITransport,
 )
 from twisted.internet.protocol import ClientFactory, DatagramProtocol, Factory
+from twisted.internet.testing import AccumulatingProtocol, MemoryReactorClock
 from twisted.python import threadpool
 from twisted.python.failure import Failure
-from twisted.test.proto_helpers import AccumulatingProtocol, MemoryReactorClock
 from twisted.web.http_headers import Headers
 from twisted.web.resource import IResource
 from twisted.web.server import Request, Site

--- a/tests/server.py
+++ b/tests/server.py
@@ -391,12 +391,6 @@ def make_request(
     # Twisted expects to be at the end of the content when parsing the request.
     req.content.seek(0, SEEK_END)
 
-    # Old version of Twisted (<20.3.0) have issues with parsing x-www-form-urlencoded
-    # bodies if the Content-Length header is missing
-    req.requestHeaders.addRawHeader(
-        b"Content-Length", str(len(content)).encode("ascii")
-    )
-
     if access_token:
         req.requestHeaders.addRawHeader(
             b"Authorization", b"Bearer " + access_token.encode("ascii")

--- a/tests/server_notices/test_consent.py
+++ b/tests/server_notices/test_consent.py
@@ -14,7 +14,7 @@
 
 import os
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.rest import admin
 from relapse.rest.client import login, room, sync

--- a/tests/server_notices/test_resource_limits_server_notices.py
+++ b/tests/server_notices/test_resource_limits_server_notices.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from unittest.mock import AsyncMock, Mock
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EventTypes, LimitBlockingTypes, ServerNoticeMsgType
 from relapse.api.errors import ResourceLimitError

--- a/tests/storage/databases/main/test_deviceinbox.py
+++ b/tests/storage/databases/main/test_deviceinbox.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.rest import admin
 from relapse.rest.client import devices

--- a/tests/storage/databases/main/test_end_to_end_keys.py
+++ b/tests/storage/databases/main/test_end_to_end_keys.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from typing import Optional
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.server import HomeServer
 from relapse.storage._base import db_to_json

--- a/tests/storage/databases/main/test_events_worker.py
+++ b/tests/storage/databases/main/test_events_worker.py
@@ -18,7 +18,7 @@ from unittest import mock
 
 from twisted.enterprise.adbapi import ConnectionPool
 from twisted.internet.defer import CancelledError, Deferred, ensureDeferred
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.room_versions import EventFormatVersions, RoomVersions
 from relapse.events import make_event_from_dict

--- a/tests/storage/databases/main/test_lock.py
+++ b/tests/storage/databases/main/test_lock.py
@@ -16,7 +16,7 @@
 from twisted.internet import defer, reactor
 from twisted.internet.base import ReactorBase
 from twisted.internet.defer import Deferred
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.server import HomeServer
 from relapse.storage.databases.main.lock import _LOCK_TIMEOUT_MS, _RENEWAL_INTERVAL_MS

--- a/tests/storage/databases/main/test_receipts.py
+++ b/tests/storage/databases/main/test_receipts.py
@@ -15,7 +15,7 @@
 from collections.abc import Sequence
 from typing import Any, Optional
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.rest import admin
 from relapse.rest.client import login, room

--- a/tests/storage/databases/main/test_room.py
+++ b/tests/storage/databases/main/test_room.py
@@ -14,7 +14,7 @@
 
 import json
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import RoomTypes
 from relapse.rest import admin

--- a/tests/storage/test__base.py
+++ b/tests/storage/test__base.py
@@ -17,7 +17,7 @@ import secrets
 from collections.abc import Generator
 from typing import cast
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.server import HomeServer
 from relapse.util import Clock

--- a/tests/storage/test_account_data.py
+++ b/tests/storage/test_account_data.py
@@ -15,7 +15,7 @@
 from collections.abc import Iterable
 from typing import Optional
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import AccountDataTypes
 from relapse.server import HomeServer

--- a/tests/storage/test_appservice.py
+++ b/tests/storage/test_appservice.py
@@ -20,7 +20,7 @@ from unittest.mock import AsyncMock, Mock
 import yaml
 
 from twisted.internet import defer
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.appservice import ApplicationService, ApplicationServiceState
 from relapse.config._base import ConfigError

--- a/tests/storage/test_background_update.py
+++ b/tests/storage/test_background_update.py
@@ -18,7 +18,7 @@ from unittest.mock import AsyncMock, Mock
 import yaml
 
 from twisted.internet.defer import Deferred, ensureDeferred
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.server import HomeServer
 from relapse.storage.background_updates import (

--- a/tests/storage/test_cleanup_extrems.py
+++ b/tests/storage/test_cleanup_extrems.py
@@ -15,7 +15,7 @@
 import os.path
 from unittest.mock import Mock, patch
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EventTypes
 from relapse.rest import admin

--- a/tests/storage/test_client_ips.py
+++ b/tests/storage/test_client_ips.py
@@ -18,7 +18,7 @@ from unittest.mock import AsyncMock
 
 from parameterized import parameterized
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.http.site import XForwardedForRequest
 from relapse.rest import admin

--- a/tests/storage/test_database.py
+++ b/tests/storage/test_database.py
@@ -17,7 +17,7 @@ from unittest.mock import Mock, call
 
 from twisted.internet import defer
 from twisted.internet.defer import CancelledError, Deferred
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.server import HomeServer
 from relapse.storage.database import (

--- a/tests/storage/test_devices.py
+++ b/tests/storage/test_devices.py
@@ -14,7 +14,7 @@
 
 from collections.abc import Collection
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 import relapse.api.errors
 from relapse.api.constants import EduTypes

--- a/tests/storage/test_directory.py
+++ b/tests/storage/test_directory.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.server import HomeServer
 from relapse.types import RoomAlias, RoomID

--- a/tests/storage/test_e2e_room_keys.py
+++ b/tests/storage/test_e2e_room_keys.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.server import HomeServer
 from relapse.storage.databases.main.e2e_room_keys import RoomKey

--- a/tests/storage/test_end_to_end_keys.py
+++ b/tests/storage/test_end_to_end_keys.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.server import HomeServer
 from relapse.util import Clock

--- a/tests/storage/test_event_chain.py
+++ b/tests/storage/test_event_chain.py
@@ -14,7 +14,7 @@
 
 from typing import cast
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 from twisted.trial import unittest
 
 from relapse.api.constants import EventTypes

--- a/tests/storage/test_event_federation.py
+++ b/tests/storage/test_event_federation.py
@@ -19,7 +19,7 @@ from typing import TypeVar, Union, cast
 import attr
 from parameterized import parameterized
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EventTypes
 from relapse.api.room_versions import (

--- a/tests/storage/test_event_push_actions.py
+++ b/tests/storage/test_event_push_actions.py
@@ -14,7 +14,7 @@
 
 from typing import Optional
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import MAIN_TIMELINE, RelationTypes
 from relapse.rest import admin

--- a/tests/storage/test_events.py
+++ b/tests/storage/test_events.py
@@ -14,7 +14,7 @@
 
 from typing import Optional
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EventTypes, Membership
 from relapse.api.room_versions import RoomVersions

--- a/tests/storage/test_id_generators.py
+++ b/tests/storage/test_id_generators.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from typing import Optional
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.server import HomeServer
 from relapse.storage.database import (

--- a/tests/storage/test_monthly_active_users.py
+++ b/tests/storage/test_monthly_active_users.py
@@ -14,7 +14,7 @@
 from typing import Any
 from unittest.mock import AsyncMock
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import UserTypes
 from relapse.server import HomeServer

--- a/tests/storage/test_profile.py
+++ b/tests/storage/test_profile.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.server import HomeServer
 from relapse.storage.database import LoggingTransaction

--- a/tests/storage/test_purge.py
+++ b/tests/storage/test_purge.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.errors import NotFoundError, RelapseError
 from relapse.rest.client import room

--- a/tests/storage/test_receipts.py
+++ b/tests/storage/test_receipts.py
@@ -15,7 +15,7 @@
 from collections.abc import Collection
 from typing import Optional
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import ReceiptTypes
 from relapse.server import HomeServer

--- a/tests/storage/test_redaction.py
+++ b/tests/storage/test_redaction.py
@@ -15,7 +15,7 @@ from typing import Optional, cast
 
 from canonicaljson import json
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EventTypes, Membership
 from relapse.api.room_versions import RoomVersions

--- a/tests/storage/test_registration.py
+++ b/tests/storage/test_registration.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import UserTypes
 from relapse.api.errors import ThreepidValidationError

--- a/tests/storage/test_relations.py
+++ b/tests/storage/test_relations.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import MAIN_TIMELINE
 from relapse.server import HomeServer

--- a/tests/storage/test_rollback_worker.py
+++ b/tests/storage/test_rollback_worker.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from unittest import mock
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.app.generic_worker import GenericWorkerServer
 from relapse.server import HomeServer

--- a/tests/storage/test_room.py
+++ b/tests/storage/test_room.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.room_versions import RoomVersions
 from relapse.server import HomeServer

--- a/tests/storage/test_room_search.py
+++ b/tests/storage/test_room_search.py
@@ -14,7 +14,7 @@
 
 from unittest.case import SkipTest
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EventTypes
 from relapse.api.errors import StoreError

--- a/tests/storage/test_roommember.py
+++ b/tests/storage/test_roommember.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 from typing import Optional, cast
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import Membership
 from relapse.rest import admin

--- a/tests/storage/test_state.py
+++ b/tests/storage/test_state.py
@@ -17,7 +17,7 @@ from typing import cast
 
 from immutabledict import immutabledict
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EventTypes, Membership
 from relapse.api.room_versions import RoomVersions

--- a/tests/storage/test_stream.py
+++ b/tests/storage/test_stream.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import Direction, EventTypes, RelationTypes
 from relapse.api.filtering import Filter

--- a/tests/storage/test_transactions.py
+++ b/tests/storage/test_transactions.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.server import HomeServer
 from relapse.storage.databases.main.transactions import DestinationRetryTimings

--- a/tests/storage/test_txn_limit.py
+++ b/tests/storage/test_txn_limit.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.server import HomeServer
 from relapse.storage.types import Cursor

--- a/tests/storage/test_user_directory.py
+++ b/tests/storage/test_user_directory.py
@@ -15,7 +15,7 @@ from typing import Any, Optional, cast
 from unittest import mock
 from unittest.mock import Mock, patch
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EventTypes, Membership, UserTypes
 from relapse.appservice import ApplicationService

--- a/tests/storage/test_user_filters.py
+++ b/tests/storage/test_user_filters.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.server import HomeServer
 from relapse.storage.database import LoggingTransaction

--- a/tests/test_federation.py
+++ b/tests/test_federation.py
@@ -16,7 +16,7 @@ from collections.abc import Collection
 from typing import Optional, Union
 from unittest.mock import AsyncMock, Mock
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.errors import FederationError
 from relapse.api.room_versions import RoomVersion, RoomVersions

--- a/tests/test_mau.py
+++ b/tests/test_mau.py
@@ -16,7 +16,7 @@
 
 from typing import Optional
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import APP_SERVICE_REGISTRATION_TYPE, LoginType
 from relapse.api.errors import Codes, HttpResponseException, RelapseError

--- a/tests/test_phone_home.py
+++ b/tests/test_phone_home.py
@@ -15,7 +15,7 @@
 import resource
 from unittest import mock
 
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.app.phone_stats_home import phone_stats_home
 from relapse.rest import admin

--- a/tests/test_terms_auth.py
+++ b/tests/test_terms_auth.py
@@ -15,7 +15,7 @@
 from unittest.mock import Mock
 
 from twisted.internet.interfaces import IReactorTime
-from twisted.test.proto_helpers import MemoryReactor, MemoryReactorClock
+from twisted.internet.testing import MemoryReactor, MemoryReactorClock
 
 from relapse.rest.client.register import register_servlets
 from relapse.server import HomeServer

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -31,9 +31,9 @@ import unpaddedbase64
 from typing_extensions import Concatenate, ParamSpec, Protocol
 
 from twisted.internet.defer import Deferred, ensureDeferred
+from twisted.internet.testing import MemoryReactor, MemoryReactorClock
 from twisted.python.failure import Failure
 from twisted.python.threadpool import ThreadPool
-from twisted.test.proto_helpers import MemoryReactor, MemoryReactorClock
 from twisted.trial import unittest
 from twisted.web.resource import Resource
 from twisted.web.server import Request

--- a/tests/util/test_task_scheduler.py
+++ b/tests/util/test_task_scheduler.py
@@ -15,7 +15,7 @@
 from typing import Optional
 
 from twisted.internet.task import deferLater
-from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.testing import MemoryReactor
 
 from relapse.server import HomeServer
 from relapse.types import JsonMapping, ScheduledTask, TaskStatus


### PR DESCRIPTION
The minimum version of Twisted was bumped and a bunch of compatibility code can be removed.