### PR TITLE
Remove backwards-compatible URLs for unsubscribe, v1 media, and push removal

### DIFF
--- a/changelog.d/186.removal
+++ b/changelog.d/186.removal
@@ -1,0 +1,1 @@
+Remove legacy unsubscribe, v1 media, and push removal URLs.

--- a/relapse/api/urls.py
+++ b/relapse/api/urls.py
@@ -28,11 +28,10 @@ FEDERATION_PREFIX = "/_matrix/federation"
 FEDERATION_V1_PREFIX = FEDERATION_PREFIX + "/v1"
 FEDERATION_V2_PREFIX = FEDERATION_PREFIX + "/v2"
 FEDERATION_UNSTABLE_PREFIX = FEDERATION_PREFIX + "/unstable"
-STATIC_PREFIX = "/_matrix/static"
+STATIC_PREFIX = "/_relapse/static"
 SERVER_KEY_PREFIX = "/_matrix/key"
 MEDIA_R0_PREFIX = "/_matrix/media/r0"
 MEDIA_V3_PREFIX = "/_matrix/media/v3"
-LEGACY_MEDIA_PREFIX = "/_matrix/media/v1"
 
 
 class ConsentURIBuilder:

--- a/relapse/app/generic_worker.py
+++ b/relapse/app/generic_worker.py
@@ -22,7 +22,6 @@ import relapse.events
 from relapse.api.urls import (
     CLIENT_API_PREFIX,
     FEDERATION_PREFIX,
-    LEGACY_MEDIA_PREFIX,
     MEDIA_R0_PREFIX,
     MEDIA_V3_PREFIX,
     SERVER_KEY_PREFIX,

--- a/relapse/app/generic_worker.py
+++ b/relapse/app/generic_worker.py
@@ -190,7 +190,6 @@ class GenericWorkerServer(HomeServer):
                             {
                                 MEDIA_R0_PREFIX: media_repo,
                                 MEDIA_V3_PREFIX: media_repo,
-                                LEGACY_MEDIA_PREFIX: media_repo,
                                 "/_relapse/admin": admin_resource,
                             }
                         )

--- a/relapse/app/homeserver.py
+++ b/relapse/app/homeserver.py
@@ -28,7 +28,6 @@ from relapse import events
 from relapse.api.urls import (
     CLIENT_API_PREFIX,
     FEDERATION_PREFIX,
-    LEGACY_MEDIA_PREFIX,
     MEDIA_R0_PREFIX,
     MEDIA_V3_PREFIX,
     SERVER_KEY_PREFIX,

--- a/relapse/app/homeserver.py
+++ b/relapse/app/homeserver.py
@@ -217,7 +217,6 @@ class RelapseHomeServer(HomeServer):
                     {
                         MEDIA_R0_PREFIX: media_repo,
                         MEDIA_V3_PREFIX: media_repo,
-                        LEGACY_MEDIA_PREFIX: media_repo,
                     }
                 )
             elif name == "media":

--- a/relapse/rest/client/pusher.py
+++ b/relapse/rest/client/pusher.py
@@ -26,7 +26,6 @@ from relapse.http.servlet import (
 from relapse.http.site import RelapseRequest
 from relapse.push import PusherConfigException
 from relapse.rest.client._base import client_patterns
-from relapse.rest.relapse.client.unsubscribe import UnsubscribeResource
 from relapse.types import JsonDict
 
 if TYPE_CHECKING:
@@ -145,20 +144,6 @@ class PushersSetRestServlet(RestServlet):
         self.notifier.on_new_replication_data()
 
         return 200, {}
-
-
-class LegacyPushersRemoveRestServlet(UnsubscribeResource, RestServlet):
-    """
-    A servlet to handle legacy "email unsubscribe" links, forwarding requests to the ``UnsubscribeResource``
-
-    This should be kept for some time, so unsubscribe links in past emails stay valid.
-    """
-
-    PATTERNS = client_patterns("/pushers/remove$", releases=(), unstable=True)
-
-    async def on_GET(self, request: RelapseRequest) -> None:
-        # Forward the request to the UnsubscribeResource
-        await self._async_render(request)
 
 
 def register_servlets(hs: "HomeServer", http_server: HttpServer) -> None:

--- a/relapse/rest/client/pusher.py
+++ b/relapse/rest/client/pusher.py
@@ -149,4 +149,3 @@ class PushersSetRestServlet(RestServlet):
 def register_servlets(hs: "HomeServer", http_server: HttpServer) -> None:
     PushersRestServlet(hs).register(http_server)
     PushersSetRestServlet(hs).register(http_server)
-    LegacyPushersRemoveRestServlet(hs).register(http_server)

--- a/relapse/rest/relapse/client/__init__.py
+++ b/relapse/rest/relapse/client/__init__.py
@@ -66,7 +66,6 @@ def build_relapse_client_resource_tree(hs: "HomeServer") -> Mapping[str, Resourc
         res = SAML2Resource(hs)
         resources["/_relapse/client/saml2"] = res
 
-
     return resources
 
 

--- a/relapse/rest/relapse/client/__init__.py
+++ b/relapse/rest/relapse/client/__init__.py
@@ -66,9 +66,6 @@ def build_relapse_client_resource_tree(hs: "HomeServer") -> Mapping[str, Resourc
         res = SAML2Resource(hs)
         resources["/_relapse/client/saml2"] = res
 
-        # This is also mounted under '/_matrix' for backwards-compatibility.
-        # To be removed in Relapse v1.32.0.
-        resources["/_matrix/saml2"] = res
 
     return resources
 


### PR DESCRIPTION
These are URLs that still exist for very old versions of Synapse.