### PR TITLE
Do not manually mount servlets in tests

### DIFF
--- a/changelog.d/355.misc
+++ b/changelog.d/355.misc
@@ -1,0 +1,1 @@
+Refactor all code to be REST servlets.

--- a/relapse/app/generic_worker.py
+++ b/relapse/app/generic_worker.py
@@ -30,8 +30,8 @@ from relapse.app._base import (
 from relapse.config._base import ConfigError
 from relapse.config.homeserver import HomeServerConfig
 from relapse.config.logger import setup_logging
-from relapse.config.server import ListenerConfig, TCPListenerConfig
-from relapse.http.server import OptionsResource
+from relapse.config.server import HttpResourceConfig, ListenerConfig, TCPListenerConfig
+from relapse.http.server import JsonResource, OptionsResource
 from relapse.logging.context import LoggingContext
 from relapse.metrics import RegistryProxy
 from relapse.replication.http import (
@@ -152,12 +152,29 @@ class GenericWorkerServer(HomeServer):
     def listen_http(self, listener_config: ListenerConfig) -> Iterable[Port]:
         assert listener_config.http_options is not None
 
+        matrix_resource = self.resource_for_listener(
+            listener_config.http_options.resources
+        )
+
+        return _base.listen_http(
+            self,
+            listener_config,
+            matrix_resource,
+            self.version_string,
+            max_request_body_size(self.config),
+            self.tls_server_context_factory,
+            reactor=self.get_reactor(),
+        )
+
+    def resource_for_listener(
+        self, resources: list[HttpResourceConfig]
+    ) -> JsonResource:
         matrix_resource = OptionsResource(self)
 
         # We always include a health resource.
         HealthServlet().register(matrix_resource)
 
-        for res in listener_config.http_options.resources:
+        for res in resources:
             for name in res.names:
                 if name == "metrics":
                     MetricsServlet(RegistryProxy).register(matrix_resource)
@@ -199,15 +216,7 @@ class GenericWorkerServer(HomeServer):
                 if name == "replication":
                     register_replication_servlets(self, matrix_resource)
 
-        return _base.listen_http(
-            self,
-            listener_config,
-            matrix_resource,
-            self.version_string,
-            max_request_body_size(self.config),
-            self.tls_server_context_factory,
-            reactor=self.get_reactor(),
-        )
+        return matrix_resource
 
     def start_listening(self) -> None:
         for listener in self.config.worker.worker_listeners:

--- a/relapse/app/generic_worker.py
+++ b/relapse/app/generic_worker.py
@@ -30,18 +30,8 @@ from relapse.app._base import (
 from relapse.config._base import ConfigError
 from relapse.config.homeserver import HomeServerConfig
 from relapse.config.logger import setup_logging
-from relapse.config.server import HttpResourceConfig, ListenerConfig, TCPListenerConfig
-from relapse.http.server import JsonResource, OptionsResource
+from relapse.config.server import ListenerConfig, TCPListenerConfig
 from relapse.logging.context import LoggingContext
-from relapse.metrics import RegistryProxy
-from relapse.replication.http import (
-    register_servlets as register_replication_servlets,
-)
-from relapse.rest import client, federation, key, media, well_known
-from relapse.rest.admin import register_servlets_for_media_repo
-from relapse.rest.health import HealthServlet
-from relapse.rest.relapse import client as relapse_client
-from relapse.rest.relapse.metrics import MetricsServlet
 from relapse.server import HomeServer
 from relapse.storage.databases.main.account_data import AccountDataWorkerStore
 from relapse.storage.databases.main.appservice import (
@@ -165,58 +155,6 @@ class GenericWorkerServer(HomeServer):
             self.tls_server_context_factory,
             reactor=self.get_reactor(),
         )
-
-    def resource_for_listener(
-        self, resources: list[HttpResourceConfig]
-    ) -> JsonResource:
-        matrix_resource = OptionsResource(self)
-
-        # We always include a health resource.
-        HealthServlet().register(matrix_resource)
-
-        for res in resources:
-            for name in res.names:
-                if name == "metrics":
-                    MetricsServlet(RegistryProxy).register(matrix_resource)
-                elif name == "client":
-                    client.register_servlets(self, matrix_resource)
-                    relapse_client.register_servlets(self, matrix_resource)
-                    well_known.register_servlets(self, matrix_resource)
-
-                elif name == "federation":
-                    federation.register_servlets(self, matrix_resource)
-                elif name == "media":
-                    if self.config.media.can_load_media_repo:
-                        media.register_servlets(self, matrix_resource)
-
-                        # We need to serve the admin servlets for media on the
-                        # worker.
-                        register_servlets_for_media_repo(self, matrix_resource)
-
-                    else:
-                        logger.warning(
-                            "A 'media' listener is configured but the media"
-                            " repository is disabled. Ignoring."
-                        )
-                elif name == "health":
-                    # Skip loading, health resource is always included
-                    continue
-
-                if name == "openid" and "federation" not in res.names:
-                    # Only load the openid resource separately if federation resource
-                    # is not specified since federation resource includes openid
-                    # resource.
-                    federation.register_servlets(
-                        self, matrix_resource, servlet_groups=["openid"]
-                    )
-
-                if name in ["keys", "federation"]:
-                    key.register_servlets(self, matrix_resource)
-
-                if name == "replication":
-                    register_replication_servlets(self, matrix_resource)
-
-        return matrix_resource
 
     def start_listening(self) -> None:
         for listener in self.config.worker.worker_listeners:

--- a/relapse/app/homeserver.py
+++ b/relapse/app/homeserver.py
@@ -41,7 +41,6 @@ from relapse.config._base import ConfigError, format_config_error
 from relapse.config.homeserver import HomeServerConfig
 from relapse.config.server import HttpResourceConfig, ListenerConfig, TCPListenerConfig
 from relapse.http.server import (
-    HttpServer,
     JsonResource,
     OptionsResource,
 )
@@ -107,7 +106,55 @@ class RelapseHomeServer(HomeServer):
                     continue
                 if name in ["static", "client"]:
                     has_static_resources = True
-                self._configure_named_resource(matrix_resource, name)
+
+                    StaticServlet(
+                        re.compile(r"/_relapse/static/"),
+                        os.path.join(os.path.dirname(relapse.__file__), "static"),
+                    ).register(matrix_resource)
+
+                if name == "client":
+                    client.register_servlets(self, matrix_resource)
+                    relapse_client.register_servlets(self, matrix_resource)
+                    well_known.register_servlets(self, matrix_resource)
+                    admin.register_servlets(self, matrix_resource)
+
+                    if self.config.email.can_verify_email:
+                        from relapse.rest.relapse.client.password_reset import (
+                            PasswordResetSubmitTokenServlet,
+                        )
+
+                        PasswordResetSubmitTokenServlet(self).register(matrix_resource)
+
+                if name == "consent":
+                    from relapse.rest.consent import ConsentServlet
+
+                    ConsentServlet(self).register(matrix_resource)
+
+                if name == "federation":
+                    federation.register_servlets(self, matrix_resource)
+
+                if name == "openid":
+                    federation.register_servlets(
+                        self, matrix_resource, servlet_groups=["openid"]
+                    )
+
+                if name in ["media", "federation", "client"]:
+                    if self.config.server.enable_media_repo:
+                        media.register_servlets(self, matrix_resource)
+                    elif name == "media":
+                        raise ConfigError(
+                            "'media' resource conflicts with enable_media_repo=False"
+                        )
+
+                if name in ["keys", "federation"]:
+                    key.register_servlets(self, matrix_resource)
+
+                if name == "metrics" and self.config.metrics.enable_metrics:
+                    MetricsServlet(RegistryProxy).register(matrix_resource)
+
+                if name == "replication":
+                    register_replication_servlets(self, matrix_resource)
+                    MetricsServlet(RegistryProxy).register(matrix_resource)
 
         # Try to find something useful to serve at '/':
         #
@@ -122,61 +169,6 @@ class RelapseHomeServer(HomeServer):
             RedirectServlet(re.compile(r"^/$"), STATIC_PREFIX).register(matrix_resource)
 
         return matrix_resource
-
-    def _configure_named_resource(self, resource: HttpServer, name: str) -> None:
-        """Build a resource map for a named resource
-
-        Args:
-            resource: The resource to attach servlets to
-            name: named resource: one of "client", "federation", etc
-        """
-        if name == "client":
-            client.register_servlets(self, resource)
-            relapse_client.register_servlets(self, resource)
-            well_known.register_servlets(self, resource)
-            admin.register_servlets(self, resource)
-
-            if self.config.email.can_verify_email:
-                from relapse.rest.relapse.client.password_reset import (
-                    PasswordResetSubmitTokenServlet,
-                )
-
-                PasswordResetSubmitTokenServlet(self).register(resource)
-
-        if name == "consent":
-            from relapse.rest.consent import ConsentServlet
-
-            ConsentServlet(self).register(resource)
-
-        if name == "federation":
-            federation.register_servlets(self, resource)
-
-        if name == "openid":
-            federation.register_servlets(self, resource, servlet_groups=["openid"])
-
-        if name in ["static", "client"]:
-            StaticServlet(
-                re.compile(r"/_relapse/static/"),
-                os.path.join(os.path.dirname(relapse.__file__), "static"),
-            ).register(resource)
-
-        if name in ["media", "federation", "client"]:
-            if self.config.server.enable_media_repo:
-                media.register_servlets(self, resource)
-            elif name == "media":
-                raise ConfigError(
-                    "'media' resource conflicts with enable_media_repo=False"
-                )
-
-        if name in ["keys", "federation"]:
-            key.register_servlets(self, resource)
-
-        if name == "metrics" and self.config.metrics.enable_metrics:
-            MetricsServlet(RegistryProxy).register(resource)
-
-        if name == "replication":
-            register_replication_servlets(self, resource)
-            MetricsServlet(RegistryProxy).register(resource)
 
     def start_listening(self) -> None:
         if self.config.redis.redis_enabled:

--- a/relapse/app/homeserver.py
+++ b/relapse/app/homeserver.py
@@ -39,9 +39,10 @@ from relapse.app._base import (
 )
 from relapse.config._base import ConfigError, format_config_error
 from relapse.config.homeserver import HomeServerConfig
-from relapse.config.server import ListenerConfig, TCPListenerConfig
+from relapse.config.server import HttpResourceConfig, ListenerConfig, TCPListenerConfig
 from relapse.http.server import (
     HttpServer,
+    JsonResource,
     OptionsResource,
 )
 from relapse.http.servlet import RedirectServlet, StaticServlet
@@ -72,13 +73,30 @@ class RelapseHomeServer(HomeServer):
         # Must exist since this is an HTTP listener.
         assert listener_config.http_options is not None
 
+        matrix_resource = self.resource_for_listener(
+            listener_config.http_options.resources
+        )
+
+        return listen_http(
+            self,
+            listener_config,
+            matrix_resource,
+            self.version_string,
+            max_request_body_size(self.config),
+            self.tls_server_context_factory,
+            reactor=self.get_reactor(),
+        )
+
+    def resource_for_listener(
+        self, resources: list[HttpResourceConfig]
+    ) -> JsonResource:
         matrix_resource = OptionsResource(self)
 
         # We always include a health resource.
         HealthServlet().register(matrix_resource)
 
         has_static_resources = False
-        for res in listener_config.http_options.resources:
+        for res in resources:
             for name in res.names:
                 if name == "openid" and "federation" in res.names:
                     # Skip loading openid resource if federation is defined
@@ -103,15 +121,7 @@ class RelapseHomeServer(HomeServer):
         elif has_static_resources:
             RedirectServlet(re.compile(r"^/$"), STATIC_PREFIX).register(matrix_resource)
 
-        return listen_http(
-            self,
-            listener_config,
-            matrix_resource,
-            self.version_string,
-            max_request_body_size(self.config),
-            self.tls_server_context_factory,
-            reactor=self.get_reactor(),
-        )
+        return matrix_resource
 
     def _configure_named_resource(self, resource: HttpServer, name: str) -> None:
         """Build a resource map for a named resource

--- a/relapse/app/homeserver.py
+++ b/relapse/app/homeserver.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 
 import logging
-import os
-import re
 import sys
 from collections.abc import Iterable
 
@@ -26,9 +24,6 @@ from twisted.web.server import GzipEncoderFactory
 import relapse
 import relapse.config.logger
 from relapse import events
-from relapse.api.urls import (
-    STATIC_PREFIX,
-)
 from relapse.app import _base
 from relapse.app._base import (
     handle_startup_exception,
@@ -39,21 +34,8 @@ from relapse.app._base import (
 )
 from relapse.config._base import ConfigError, format_config_error
 from relapse.config.homeserver import HomeServerConfig
-from relapse.config.server import HttpResourceConfig, ListenerConfig, TCPListenerConfig
-from relapse.http.server import (
-    JsonResource,
-    OptionsResource,
-)
-from relapse.http.servlet import RedirectServlet, StaticServlet
+from relapse.config.server import ListenerConfig, TCPListenerConfig
 from relapse.logging.context import LoggingContext
-from relapse.metrics import RegistryProxy
-from relapse.replication.http import (
-    register_servlets as register_replication_servlets,
-)
-from relapse.rest import admin, client, federation, key, media, well_known
-from relapse.rest.health import HealthServlet
-from relapse.rest.relapse import client as relapse_client
-from relapse.rest.relapse.metrics import MetricsServlet
 from relapse.server import HomeServer
 from relapse.storage import DataStore
 from relapse.util.check_dependencies import VERSION, check_requirements
@@ -85,90 +67,6 @@ class RelapseHomeServer(HomeServer):
             self.tls_server_context_factory,
             reactor=self.get_reactor(),
         )
-
-    def resource_for_listener(
-        self, resources: list[HttpResourceConfig]
-    ) -> JsonResource:
-        matrix_resource = OptionsResource(self)
-
-        # We always include a health resource.
-        HealthServlet().register(matrix_resource)
-
-        has_static_resources = False
-        for res in resources:
-            for name in res.names:
-                if name == "openid" and "federation" in res.names:
-                    # Skip loading openid resource if federation is defined
-                    # since federation resource will include openid
-                    continue
-                if name == "health":
-                    # Skip loading, health resource is always included
-                    continue
-                if name in ["static", "client"]:
-                    has_static_resources = True
-
-                    StaticServlet(
-                        re.compile(r"/_relapse/static/"),
-                        os.path.join(os.path.dirname(relapse.__file__), "static"),
-                    ).register(matrix_resource)
-
-                if name == "client":
-                    client.register_servlets(self, matrix_resource)
-                    relapse_client.register_servlets(self, matrix_resource)
-                    well_known.register_servlets(self, matrix_resource)
-                    admin.register_servlets(self, matrix_resource)
-
-                    if self.config.email.can_verify_email:
-                        from relapse.rest.relapse.client.password_reset import (
-                            PasswordResetSubmitTokenServlet,
-                        )
-
-                        PasswordResetSubmitTokenServlet(self).register(matrix_resource)
-
-                if name == "consent":
-                    from relapse.rest.consent import ConsentServlet
-
-                    ConsentServlet(self).register(matrix_resource)
-
-                if name == "federation":
-                    federation.register_servlets(self, matrix_resource)
-
-                if name == "openid":
-                    federation.register_servlets(
-                        self, matrix_resource, servlet_groups=["openid"]
-                    )
-
-                if name in ["media", "federation", "client"]:
-                    if self.config.server.enable_media_repo:
-                        media.register_servlets(self, matrix_resource)
-                    elif name == "media":
-                        raise ConfigError(
-                            "'media' resource conflicts with enable_media_repo=False"
-                        )
-
-                if name in ["keys", "federation"]:
-                    key.register_servlets(self, matrix_resource)
-
-                if name == "metrics" and self.config.metrics.enable_metrics:
-                    MetricsServlet(RegistryProxy).register(matrix_resource)
-
-                if name == "replication":
-                    register_replication_servlets(self, matrix_resource)
-                    MetricsServlet(RegistryProxy).register(matrix_resource)
-
-        # Try to find something useful to serve at '/':
-        #
-        # 1. Redirect to the web client if it is an HTTP(S) URL.
-        # 2. Redirect to the static "Relapse is running" page.
-        # 3. Do not redirect and use a blank resource.
-        if self.config.server.web_client_location:
-            RedirectServlet(
-                re.compile(r"^/$"), self.config.server.web_client_location
-            ).register(matrix_resource)
-        elif has_static_resources:
-            RedirectServlet(re.compile(r"^/$"), STATIC_PREFIX).register(matrix_resource)
-
-        return matrix_resource
 
     def start_listening(self) -> None:
         if self.config.redis.redis_enabled:

--- a/relapse/rest/client/openid.py
+++ b/relapse/rest/client/openid.py
@@ -99,4 +99,5 @@ class IdTokenServlet(RestServlet):
 
 
 def register_servlets(hs: "HomeServer", http_server: HttpServer) -> None:
-    IdTokenServlet(hs).register(http_server)
+    if not hs.config.experimental.msc3861.enabled:
+        IdTokenServlet(hs).register(http_server)

--- a/relapse/server.py
+++ b/relapse/server.py
@@ -37,7 +37,7 @@ from relapse.api.ratelimiting import Ratelimiter, RequestRatelimiter
 from relapse.appservice.api import ApplicationServiceApi
 from relapse.appservice.scheduler import ApplicationServiceScheduler
 from relapse.config.homeserver import HomeServerConfig
-from relapse.config.server import ListenerConfig
+from relapse.config.server import HttpResourceConfig, ListenerConfig
 from relapse.crypto import context_factory
 from relapse.crypto.context_factory import RegularPolicyForHTTPS
 from relapse.crypto.keyring import Keyring
@@ -112,6 +112,7 @@ from relapse.http.client import (
     SimpleHttpClient,
 )
 from relapse.http.matrixfederationclient import MatrixFederationHttpClient
+from relapse.http.server import JsonResource
 from relapse.media.media_repository import MediaRepository
 from relapse.metrics.common_usage_metrics import CommonUsageMetricsManager
 from relapse.module_api import ModuleApi
@@ -356,6 +357,11 @@ class HomeServer(metaclass=abc.ABCMeta):
     def listen_http(self, listener_config: ListenerConfig) -> Iterable[Port]:  # noqa: B027 (no-op by design)
         """Configure a single HTTP listener."""
         return ()
+
+    def resource_for_listener(
+        self, resources: list[HttpResourceConfig]
+    ) -> JsonResource:
+        pass
 
     def setup_background_tasks(self) -> None:
         """

--- a/relapse/server.py
+++ b/relapse/server.py
@@ -21,6 +21,8 @@
 import abc
 import functools
 import logging
+import os
+import re
 from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING, Any, TypeAlias, TypeVar, cast
 
@@ -29,13 +31,16 @@ from twisted.internet.tcp import Port
 from twisted.web.iweb import IPolicyForHTTPS
 from twisted.web.resource import Resource
 
+import relapse
 from relapse.api.auth import Auth
 from relapse.api.auth.internal import InternalAuth
 from relapse.api.auth_blocking import AuthBlocking
 from relapse.api.filtering import Filtering
 from relapse.api.ratelimiting import Ratelimiter, RequestRatelimiter
+from relapse.api.urls import STATIC_PREFIX
 from relapse.appservice.api import ApplicationServiceApi
 from relapse.appservice.scheduler import ApplicationServiceScheduler
+from relapse.config import ConfigError
 from relapse.config.homeserver import HomeServerConfig
 from relapse.config.server import HttpResourceConfig, ListenerConfig
 from relapse.crypto import context_factory
@@ -112,19 +117,32 @@ from relapse.http.client import (
     SimpleHttpClient,
 )
 from relapse.http.matrixfederationclient import MatrixFederationHttpClient
-from relapse.http.server import JsonResource
+from relapse.http.server import (
+    JsonResource,
+    OptionsResource,
+)
+from relapse.http.servlet import RedirectServlet, StaticServlet
 from relapse.media.media_repository import MediaRepository
+from relapse.metrics import RegistryProxy
 from relapse.metrics.common_usage_metrics import CommonUsageMetricsManager
 from relapse.module_api import ModuleApi
 from relapse.module_api.callbacks import ModuleApiCallbacks
 from relapse.notifier import Notifier, ReplicationNotifier
 from relapse.push.bulk_push_rule_evaluator import BulkPushRuleEvaluator
 from relapse.push.pusherpool import PusherPool
+from relapse.replication.http import (
+    register_servlets as register_replication_servlets,
+)
 from relapse.replication.tcp.client import ReplicationDataHandler
 from relapse.replication.tcp.external_cache import ExternalCache
 from relapse.replication.tcp.handler import ReplicationCommandHandler
 from relapse.replication.tcp.resource import ReplicationStreamer
 from relapse.replication.tcp.streams import STREAMS_MAP, Stream
+from relapse.rest import admin, client, federation, key, media, well_known
+from relapse.rest.admin import register_servlets_for_media_repo
+from relapse.rest.health import HealthServlet
+from relapse.rest.relapse import client as relapse_client
+from relapse.rest.relapse.metrics import MetricsServlet
 from relapse.server_notices.server_notices_manager import ServerNoticesManager
 from relapse.server_notices.server_notices_sender import ServerNoticesSender
 from relapse.server_notices.worker_server_notices_sender import (
@@ -361,7 +379,94 @@ class HomeServer(metaclass=abc.ABCMeta):
     def resource_for_listener(
         self, resources: list[HttpResourceConfig]
     ) -> JsonResource:
-        pass
+        matrix_resource = OptionsResource(self)
+
+        # We always include a health resource.
+        HealthServlet().register(matrix_resource)
+
+        is_main_process = self.config.worker.worker_app is None
+
+        has_static_resources = False
+        for res in resources:
+            for name in res.names:
+                if name == "health":
+                    # Skip loading, health resource is always included
+                    continue
+
+                if name in ["static", "client"]:
+                    has_static_resources = True
+
+                    StaticServlet(
+                        re.compile(r"/_relapse/static/"),
+                        os.path.join(os.path.dirname(relapse.__file__), "static"),
+                    ).register(matrix_resource)
+
+                if name == "client":
+                    client.register_servlets(self, matrix_resource)
+                    relapse_client.register_servlets(self, matrix_resource)
+                    well_known.register_servlets(self, matrix_resource)
+                    admin.register_servlets(self, matrix_resource)
+
+                    if is_main_process:
+                        if self.config.email.can_verify_email:
+                            from relapse.rest.relapse.client.password_reset import (
+                                PasswordResetSubmitTokenServlet,
+                            )
+
+                            PasswordResetSubmitTokenServlet(self).register(
+                                matrix_resource
+                            )
+
+                if name == "consent" and is_main_process:
+                    from relapse.rest.consent import ConsentServlet
+
+                    ConsentServlet(self).register(matrix_resource)
+
+                if name == "federation":
+                    federation.register_servlets(self, matrix_resource)
+
+                # Skip loading openid resource if federation is defined
+                # since federation resource will include openid
+                if name == "openid" and "federation" not in res.names:
+                    federation.register_servlets(
+                        self, matrix_resource, servlet_groups=["openid"]
+                    )
+
+                if name in ["media", "federation", "client"]:
+                    if self.config.media.can_load_media_repo:
+                        media.register_servlets(self, matrix_resource)
+
+                        if not is_main_process:
+                            # We need to serve the admin servlets for media on the worker.
+                            register_servlets_for_media_repo(self, matrix_resource)
+                    elif name == "media":
+                        raise ConfigError(
+                            "A 'media' listener is configured but the media"
+                            " repository is disabled. Ignoring."
+                        )
+
+                if name in ["keys", "federation"]:
+                    key.register_servlets(self, matrix_resource)
+
+                if name == "metrics" and self.config.metrics.enable_metrics:
+                    MetricsServlet(RegistryProxy).register(matrix_resource)
+
+                if name == "replication":
+                    register_replication_servlets(self, matrix_resource)
+
+        # Try to find something useful to serve at '/':
+        #
+        # 1. Redirect to the web client if it is an HTTP(S) URL.
+        # 2. Redirect to the static "Relapse is running" page.
+        # 3. Do not redirect and use a blank resource.
+        if self.config.server.web_client_location:
+            RedirectServlet(
+                re.compile(r"^/$"), self.config.server.web_client_location
+            ).register(matrix_resource)
+        elif has_static_resources:
+            RedirectServlet(re.compile(r"^/$"), STATIC_PREFIX).register(matrix_resource)
+
+        return matrix_resource
 
     def setup_background_tasks(self) -> None:
         """

--- a/tests/app/test_phone_stats_home.py
+++ b/tests/app/test_phone_stats_home.py
@@ -1,6 +1,4 @@
 from relapse.app.phone_stats_home import start_phone_stats_home
-from relapse.rest import admin
-from relapse.rest.client import login, room
 from relapse.server import HomeServer
 from relapse.util import Clock
 

--- a/tests/app/test_phone_stats_home.py
+++ b/tests/app/test_phone_stats_home.py
@@ -12,12 +12,6 @@ ONE_DAY_IN_SECONDS = 86400
 
 
 class PhoneHomeR30V2TestCase(HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-    ]
-
     def _advance_to(self, desired_time_secs: float) -> None:
         now = self.hs.get_clock().time()
         assert now < desired_time_secs

--- a/tests/events/test_presence_router.py
+++ b/tests/events/test_presence_router.py
@@ -23,8 +23,6 @@ from relapse.events.presence_router import PresenceRouter
 from relapse.federation.units import Transaction
 from relapse.handlers.presence import UserPresenceState
 from relapse.module_api import ModuleApi
-from relapse.rest import admin
-from relapse.rest.client import login, presence, room
 from relapse.server import HomeServer
 from relapse.types import JsonDict, StreamToken, create_requester
 from relapse.util import Clock

--- a/tests/events/test_presence_router.py
+++ b/tests/events/test_presence_router.py
@@ -100,13 +100,6 @@ class PresenceRouterTestCase(FederatingHomeserverTestCase):
     for the main process by setting `federation_sender_instances` to None.
     """
 
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        room.register_servlets,
-        presence.register_servlets,
-    ] + FederatingHomeserverTestCase.servlets
-
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         # Mock out the calls over federation.
         self.federation_client = Mock(spec=["send_transaction"])

--- a/tests/events/test_snapshot.py
+++ b/tests/events/test_snapshot.py
@@ -26,12 +26,6 @@ from tests.test_utils.event_injection import create_event
 
 
 class TestEventContext(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        room.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.store = hs.get_datastores().main
         self._storage_controllers = hs.get_storage_controllers()

--- a/tests/events/test_snapshot.py
+++ b/tests/events/test_snapshot.py
@@ -16,8 +16,6 @@ from twisted.internet.testing import MemoryReactor
 
 from relapse.events import EventBase
 from relapse.events.snapshot import EventContext
-from relapse.rest import admin
-from relapse.rest.client import login, room
 from relapse.server import HomeServer
 from relapse.util import Clock
 

--- a/tests/federation/test_complexity.py
+++ b/tests/federation/test_complexity.py
@@ -15,8 +15,6 @@
 from unittest.mock import AsyncMock
 
 from relapse.api.errors import Codes, RelapseError
-from relapse.rest import admin
-from relapse.rest.client import login, room
 from relapse.types import JsonDict, UserID, create_requester
 
 from tests.unittest import FederatingHomeserverTestCase

--- a/tests/federation/test_complexity.py
+++ b/tests/federation/test_complexity.py
@@ -23,12 +23,6 @@ from tests.unittest import FederatingHomeserverTestCase
 
 
 class RoomComplexityTests(FederatingHomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-    ] + FederatingHomeserverTestCase.servlets
-
     def default_config(self) -> JsonDict:
         config = super().default_config()
         config["limit_remote_rooms"] = {"enabled": True, "complexity": 0.05}
@@ -175,12 +169,6 @@ class RoomComplexityTests(FederatingHomeserverTestCase):
 class RoomComplexityAdminTests(FederatingHomeserverTestCase):
     # Test the behavior of joining rooms which exceed the complexity if option
     # limit_remote_rooms.admins_can_join is True.
-
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-    ] + FederatingHomeserverTestCase.servlets
 
     def default_config(self) -> JsonDict:
         config = super().default_config()

--- a/tests/federation/test_federation_catch_up.py
+++ b/tests/federation/test_federation_catch_up.py
@@ -31,12 +31,6 @@ class FederationCatchUpTestCases(FederatingHomeserverTestCase):
     re-enabled for the main process.
     """
 
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-    ] + FederatingHomeserverTestCase.servlets
-
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         self.federation_client = Mock(spec=["send_transaction"])
         return self.setup_test_homeserver(

--- a/tests/federation/test_federation_catch_up.py
+++ b/tests/federation/test_federation_catch_up.py
@@ -12,8 +12,6 @@ from relapse.federation.sender import (
     TransactionManager,
 )
 from relapse.federation.units import Edu, Transaction
-from relapse.rest import admin
-from relapse.rest.client import login, room
 from relapse.server import HomeServer
 from relapse.types import JsonDict
 from relapse.util import Clock

--- a/tests/federation/test_federation_client.py
+++ b/tests/federation/test_federation_client.py
@@ -30,12 +30,6 @@ from tests.unittest import FederatingHomeserverTestCase
 
 
 class FederationClientTest(FederatingHomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-    ] + FederatingHomeserverTestCase.servlets
-
     def prepare(
         self, reactor: MemoryReactor, clock: Clock, homeserver: HomeServer
     ) -> None:

--- a/tests/federation/test_federation_client.py
+++ b/tests/federation/test_federation_client.py
@@ -20,8 +20,6 @@ from twisted.internet.testing import MemoryReactor
 
 from relapse.api.room_versions import RoomVersions
 from relapse.events import EventBase
-from relapse.rest import admin
-from relapse.rest.client import login, room
 from relapse.server import HomeServer
 from relapse.util import Clock
 

--- a/tests/federation/test_federation_sender.py
+++ b/tests/federation/test_federation_sender.py
@@ -268,11 +268,6 @@ class FederationSenderDevicesTestCases(HomeserverTestCase):
     re-enabled for the main process.
     """
 
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-    ]
-
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         self.federation_client = Mock(spec=["send_transaction", "query_user_devices"])
         self.federation_client.send_transaction = AsyncMock()

--- a/tests/federation/test_federation_sender.py
+++ b/tests/federation/test_federation_sender.py
@@ -23,8 +23,6 @@ from twisted.internet.testing import MemoryReactor
 from relapse.api.constants import EduTypes, RoomEncryptionAlgorithms
 from relapse.federation.units import Transaction
 from relapse.handlers.device import DeviceHandler
-from relapse.rest import admin
-from relapse.rest.client import login
 from relapse.server import HomeServer
 from relapse.types import JsonDict, ReadReceipt
 from relapse.util import Clock

--- a/tests/federation/test_federation_server.py
+++ b/tests/federation/test_federation_server.py
@@ -22,8 +22,6 @@ from twisted.internet.testing import MemoryReactor
 from relapse.api.room_versions import KNOWN_ROOM_VERSIONS
 from relapse.config.server import DEFAULT_ROOM_VERSION
 from relapse.events import EventBase, make_event_from_dict
-from relapse.rest import admin
-from relapse.rest.client import login, room
 from relapse.server import HomeServer
 from relapse.storage.controllers.state import server_acl_evaluator_from_event
 from relapse.types import JsonDict

--- a/tests/federation/test_federation_server.py
+++ b/tests/federation/test_federation_server.py
@@ -34,12 +34,6 @@ from tests.unittest import FederatingHomeserverTestCase, override_config
 
 
 class FederationServerTests(FederatingHomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-    ] + FederatingHomeserverTestCase.servlets
-
     @parameterized.expand([(b"",), (b"foo",), (b'{"limit": Infinity}',)])
     def test_bad_request(self, query_content: bytes) -> None:
         """
@@ -110,12 +104,6 @@ class ServerACLsTestCase(unittest.TestCase):
 
 
 class StateQueryTests(FederatingHomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-    ] + FederatingHomeserverTestCase.servlets
-
     def test_needs_to_be_in_room(self) -> None:
         """/v1/state/<room_id> requires the server to be in the room"""
         u1 = self.register_user("u1", "pass")
@@ -131,12 +119,6 @@ class StateQueryTests(FederatingHomeserverTestCase):
 
 
 class SendJoinFederationTests(FederatingHomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-    ] + FederatingHomeserverTestCase.servlets
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         super().prepare(reactor, clock, hs)
 

--- a/tests/handlers/test_admin.py
+++ b/tests/handlers/test_admin.py
@@ -29,13 +29,6 @@ from tests import unittest
 
 
 class ExfiltrateData(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        room.register_servlets,
-        knock.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.admin_handler = hs.get_admin_handler()
         self._store = hs.get_datastores().main

--- a/tests/handlers/test_admin.py
+++ b/tests/handlers/test_admin.py
@@ -19,8 +19,6 @@ from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EventTypes, JoinRules
 from relapse.api.room_versions import RoomVersions
-from relapse.rest import admin
-from relapse.rest.client import knock, login, room
 from relapse.server import HomeServer
 from relapse.types import UserID
 from relapse.util import Clock

--- a/tests/handlers/test_appservice.py
+++ b/tests/handlers/test_appservice.py
@@ -27,8 +27,6 @@ from relapse.appservice import (
     TransactionUnusedFallbackKeys,
 )
 from relapse.handlers.appservice import ApplicationServicesHandler
-from relapse.rest import admin
-from relapse.rest.client import login, receipts, register, room, sendtodevice
 from relapse.server import HomeServer
 from relapse.types import (
     JsonDict,

--- a/tests/handlers/test_appservice.py
+++ b/tests/handlers/test_appservice.py
@@ -396,14 +396,6 @@ class ApplicationServicesHandlerSendEventsTestCase(unittest.HomeserverTestCase):
     services correctly.
     """
 
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        room.register_servlets,
-        sendtodevice.register_servlets,
-        receipts.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.hs = hs
         # Mock the ApplicationServiceScheduler's _TransactionController's send method so that
@@ -1019,12 +1011,6 @@ class ApplicationServicesHandlerDeviceListsTestCase(unittest.HomeserverTestCase)
     services correctly.
     """
 
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        room.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         # Allow us to modify cached feature flags mid-test
         self.as_handler = hs.get_application_service_handler()
@@ -1124,15 +1110,6 @@ class ApplicationServicesHandlerOtkCountsTestCase(unittest.HomeserverTestCase):
     # Argument indices for pulling out arguments from a `send_mock`.
     ARG_OTK_COUNTS = 4
     ARG_FALLBACK_KEYS = 5
-
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        register.register_servlets,
-        room.register_servlets,
-        sendtodevice.register_servlets,
-        receipts.register_servlets,
-    ]
 
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         # Mock the ApplicationServiceScheduler's _TransactionController's send method so that

--- a/tests/handlers/test_auth.py
+++ b/tests/handlers/test_auth.py
@@ -18,8 +18,6 @@ import pymacaroons
 from twisted.internet.testing import MemoryReactor
 
 from relapse.api.errors import AuthError, ResourceLimitError
-from relapse.rest import admin
-from relapse.rest.client import login
 from relapse.server import HomeServer
 from relapse.util import Clock
 

--- a/tests/handlers/test_auth.py
+++ b/tests/handlers/test_auth.py
@@ -27,11 +27,6 @@ from tests import unittest
 
 
 class AuthTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.auth_handler = hs.get_auth_handler()
         self.macaroon_generator = hs.get_macaroon_generator()

--- a/tests/handlers/test_deactivate_account.py
+++ b/tests/handlers/test_deactivate_account.py
@@ -26,12 +26,6 @@ from tests.unittest import HomeserverTestCase
 
 
 class DeactivateAccountTestCase(HomeserverTestCase):
-    servlets = [
-        login.register_servlets,
-        admin.register_servlets,
-        account.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self._store = hs.get_datastores().main
 

--- a/tests/handlers/test_deactivate_account.py
+++ b/tests/handlers/test_deactivate_account.py
@@ -17,8 +17,6 @@ from twisted.internet.testing import MemoryReactor
 from relapse.api.constants import AccountDataTypes
 from relapse.push.rulekinds import PRIORITY_CLASS_MAP
 from relapse.relapse_rust.push import PushRule
-from relapse.rest import admin
-from relapse.rest.client import account, login
 from relapse.server import HomeServer
 from relapse.util import Clock
 

--- a/tests/handlers/test_device.py
+++ b/tests/handlers/test_device.py
@@ -445,13 +445,6 @@ class DeviceTestCase(unittest.HomeserverTestCase):
 
 
 class DehydrationTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        register.register_servlets,
-        devices.register_servlets,
-    ]
-
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         hs = self.setup_test_homeserver("server")
         handler = hs.get_device_handler()

--- a/tests/handlers/test_device.py
+++ b/tests/handlers/test_device.py
@@ -23,8 +23,6 @@ from relapse.api.constants import RoomEncryptionAlgorithms
 from relapse.api.errors import NotFoundError, RelapseError
 from relapse.appservice import ApplicationService
 from relapse.handlers.device import MAX_DEVICE_DISPLAY_NAME_LEN, DeviceHandler
-from relapse.rest import admin
-from relapse.rest.client import devices, login, register
 from relapse.server import HomeServer
 from relapse.storage.databases.main.appservice import _make_exclusive_regex
 from relapse.types import JsonDict, create_requester

--- a/tests/handlers/test_directory.py
+++ b/tests/handlers/test_directory.py
@@ -106,13 +106,6 @@ class DirectoryTestCase(unittest.HomeserverTestCase):
 
 
 class TestCreateAlias(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        room.register_servlets,
-        directory.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.handler = hs.get_directory_handler()
 
@@ -174,13 +167,6 @@ class TestCreateAlias(unittest.HomeserverTestCase):
 
 
 class TestDeleteAlias(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        room.register_servlets,
-        directory.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.store = hs.get_datastores().main
         self.handler = hs.get_directory_handler()
@@ -289,13 +275,6 @@ class TestDeleteAlias(unittest.HomeserverTestCase):
 class CanonicalAliasTestCase(unittest.HomeserverTestCase):
     """Test modifications of the canonical alias when delete aliases."""
 
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        room.register_servlets,
-        directory.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.store = hs.get_datastores().main
         self.handler = hs.get_directory_handler()
@@ -402,8 +381,6 @@ class CanonicalAliasTestCase(unittest.HomeserverTestCase):
 class TestCreateAliasACL(unittest.HomeserverTestCase):
     user_id = "@test:test"
 
-    servlets = [directory.register_servlets, room.register_servlets]
-
     def default_config(self) -> dict[str, Any]:
         config = super().default_config()
 
@@ -459,12 +436,6 @@ class TestCreateAliasACL(unittest.HomeserverTestCase):
 
 
 class TestCreatePublishedRoomACL(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        directory.register_servlets,
-        room.register_servlets,
-    ]
     hijack_auth = False
 
     data = {"room_alias_name": "unofficial_test"}
@@ -572,8 +543,6 @@ class TestCreatePublishedRoomACL(unittest.HomeserverTestCase):
 
 class TestRoomListSearchDisabled(unittest.HomeserverTestCase):
     user_id = "@test:test"
-
-    servlets = [directory.register_servlets, room.register_servlets]
 
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         room_id = self.helper.create_room_as(self.user_id)

--- a/tests/handlers/test_directory.py
+++ b/tests/handlers/test_directory.py
@@ -21,8 +21,6 @@ from twisted.internet.testing import MemoryReactor
 import relapse.api.errors
 from relapse.api.constants import EventTypes
 from relapse.events import EventBase
-from relapse.rest import admin
-from relapse.rest.client import directory, login, room
 from relapse.server import HomeServer
 from relapse.types import JsonDict, RoomAlias, create_requester
 from relapse.util import Clock

--- a/tests/handlers/test_federation.py
+++ b/tests/handlers/test_federation.py
@@ -33,8 +33,6 @@ from relapse.events import EventBase, make_event_from_dict
 from relapse.federation.federation_base import event_from_pdu_json
 from relapse.federation.federation_client import SendJoinResult
 from relapse.logging.context import LoggingContext, run_in_background
-from relapse.rest import admin
-from relapse.rest.client import login, room
 from relapse.server import HomeServer
 from relapse.storage.databases.main.events_worker import EventCacheEntry
 from relapse.util import Clock

--- a/tests/handlers/test_federation.py
+++ b/tests/handlers/test_federation.py
@@ -52,12 +52,6 @@ def generate_fake_event_id() -> str:
 
 
 class FederationTestCase(FederatingHomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        room.register_servlets,
-    ] + FederatingHomeserverTestCase.servlets
-
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         hs = self.setup_test_homeserver()
         self.handler = hs.get_federation_handler()

--- a/tests/handlers/test_federation_event.py
+++ b/tests/handlers/test_federation_event.py
@@ -27,8 +27,6 @@ from relapse.events.snapshot import EventContext
 from relapse.federation.federation_client_helpers import StateRequestResponse
 from relapse.http.types import QueryParams
 from relapse.logging.context import LoggingContext
-from relapse.rest import admin
-from relapse.rest.client import login, room
 from relapse.server import HomeServer
 from relapse.state import StateResolutionStore
 from relapse.state.v2 import _mainline_sort, _reverse_topological_power_sort

--- a/tests/handlers/test_federation_event.py
+++ b/tests/handlers/test_federation_event.py
@@ -39,12 +39,6 @@ from tests.unittest import FederatingHomeserverTestCase
 
 
 class FederationEventHandlerTests(FederatingHomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        room.register_servlets,
-    ] + FederatingHomeserverTestCase.servlets
-
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         # mock out the federation client
         self.mock_client = mock.Mock(spec=["get_json", "agent"])

--- a/tests/handlers/test_message.py
+++ b/tests/handlers/test_message.py
@@ -32,12 +32,6 @@ logger = logging.getLogger(__name__)
 
 
 class EventCreationTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        room.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.handler = self.hs.get_event_creation_handler()
         persistence = self.hs.get_storage_controllers().persistence
@@ -279,12 +273,6 @@ class EventCreationTestCase(unittest.HomeserverTestCase):
 
 
 class ServerAclValidationTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        room.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.user_id = self.register_user("tester", "foobar")
         self.access_token = self.login("tester", "foobar")

--- a/tests/handlers/test_message.py
+++ b/tests/handlers/test_message.py
@@ -18,8 +18,6 @@ from twisted.internet.testing import MemoryReactor
 from relapse.api.constants import EventTypes
 from relapse.events import EventBase
 from relapse.events.snapshot import EventContext, UnpersistedEventContextBase
-from relapse.rest import admin
-from relapse.rest.client import login, room
 from relapse.server import HomeServer
 from relapse.types import create_requester
 from relapse.util import Clock

--- a/tests/handlers/test_oauth_delegation.py
+++ b/tests/handlers/test_oauth_delegation.py
@@ -99,16 +99,6 @@ async def get_json(url: str) -> JsonDict:
 
 @skip_unless(HAS_AUTHLIB, "requires authlib")
 class MSC3861OAuthDelegation(HomeserverTestCase):
-    servlets = [
-        account.register_servlets,
-        devices.register_servlets,
-        keys.register_servlets,
-        register.register_servlets,
-        login.register_servlets,
-        logout.register_servlets,
-        admin.register_servlets,
-    ]
-
     def default_config(self) -> dict[str, Any]:
         config = super().default_config()
         config["public_baseurl"] = BASE_URL

--- a/tests/handlers/test_oauth_delegation.py
+++ b/tests/handlers/test_oauth_delegation.py
@@ -37,8 +37,6 @@ from relapse.api.errors import (
     RelapseError,
 )
 from relapse.http.site import RelapseRequest
-from relapse.rest import admin
-from relapse.rest.client import account, devices, keys, login, logout, register
 from relapse.server import HomeServer
 from relapse.types import JsonDict, UserID
 from relapse.util import Clock

--- a/tests/handlers/test_password_providers.py
+++ b/tests/handlers/test_password_providers.py
@@ -23,8 +23,6 @@ from twisted.internet.testing import MemoryReactor
 from relapse.api.constants import LoginType
 from relapse.api.errors import Codes
 from relapse.module_api import ModuleApi
-from relapse.rest import admin
-from relapse.rest.client import account, devices, login, logout, register
 from relapse.server import HomeServer
 from relapse.types import JsonDict, UserID
 from relapse.util import Clock

--- a/tests/handlers/test_password_providers.py
+++ b/tests/handlers/test_password_providers.py
@@ -106,15 +106,6 @@ def providers_config(*providers: type[Any]) -> dict:
 
 
 class PasswordAuthProviderTests(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        devices.register_servlets,
-        logout.register_servlets,
-        register.register_servlets,
-        account.register_servlets,
-    ]
-
     CALLBACK_USERNAME = "get_username_for_registration"
     CALLBACK_DISPLAYNAME = "get_displayname_for_registration"
 

--- a/tests/handlers/test_presence.py
+++ b/tests/handlers/test_presence.py
@@ -49,8 +49,6 @@ from tests.replication._base import BaseMultiWorkerStreamTestCase
 
 
 class PresenceUpdateTestCase(unittest.HomeserverTestCase):
-    servlets = [admin.register_servlets]
-
     def prepare(
         self, reactor: MemoryReactor, clock: Clock, homeserver: HomeServer
     ) -> None:
@@ -1796,8 +1794,6 @@ class PresenceJoinTestCase(unittest.HomeserverTestCase):
     """
 
     user_id = "@test:server"
-
-    servlets = [room.register_servlets]
 
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         hs = self.setup_test_homeserver(

--- a/tests/handlers/test_presence.py
+++ b/tests/handlers/test_presence.py
@@ -37,8 +37,6 @@ from relapse.handlers.presence import (
     handle_timeout,
     handle_update,
 )
-from relapse.rest import admin
-from relapse.rest.client import room
 from relapse.server import HomeServer
 from relapse.storage.database import LoggingDatabaseConnection
 from relapse.types import JsonDict, UserID, get_domain_from_id

--- a/tests/handlers/test_presence.py
+++ b/tests/handlers/test_presence.py
@@ -686,6 +686,10 @@ class PresenceTimeoutTestCase(unittest.TestCase):
 class PresenceHandlerInitTestCase(unittest.HomeserverTestCase):
     def default_config(self) -> JsonDict:
         config = super().default_config()
+
+        # Don't load any resources to ensure the PresenceHandler isn't loaded.
+        config["listeners"][0]["resources"] = []
+
         # Disable background tasks on this worker so that the PresenceHandler isn't
         # loaded until we request it.
         config["run_background_tasks_on"] = "other"

--- a/tests/handlers/test_profile.py
+++ b/tests/handlers/test_profile.py
@@ -32,8 +32,6 @@ from tests import unittest
 class ProfileTestCase(unittest.HomeserverTestCase):
     """Tests profile management."""
 
-    servlets = [admin.register_servlets]
-
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         self.mock_federation = AsyncMock()
         self.mock_registry = Mock()

--- a/tests/handlers/test_profile.py
+++ b/tests/handlers/test_profile.py
@@ -21,7 +21,6 @@ from twisted.internet.testing import MemoryReactor
 
 import relapse.types
 from relapse.api.errors import AuthError, RelapseError
-from relapse.rest import admin
 from relapse.server import HomeServer
 from relapse.types import JsonDict, UserID
 from relapse.util import Clock

--- a/tests/handlers/test_room.py
+++ b/tests/handlers/test_room.py
@@ -7,12 +7,6 @@ from tests.unittest import override_config
 
 
 class EncryptedByDefaultTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        login.register_servlets,
-        admin.register_servlets,
-        room.register_servlets,
-    ]
-
     @override_config({"encryption_enabled_by_default_for_room_type": "all"})
     def test_encrypted_by_default_config_option_all(self) -> None:
         """Tests that invite-only and non-invite-only rooms have encryption enabled by

--- a/tests/handlers/test_room.py
+++ b/tests/handlers/test_room.py
@@ -1,6 +1,4 @@
 from relapse.api.constants import EventTypes, RoomEncryptionAlgorithms
-from relapse.rest import admin
-from relapse.rest.client import login, room
 
 from tests import unittest
 from tests.unittest import override_config

--- a/tests/handlers/test_room_member.py
+++ b/tests/handlers/test_room_member.py
@@ -24,12 +24,6 @@ from tests.unittest import (
 
 
 class TestJoinsLimitedByPerRoomRateLimiter(FederatingHomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        relapse.rest.client.login.register_servlets,
-        relapse.rest.client.room.register_servlets,
-    ] + FederatingHomeserverTestCase.servlets
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.handler = hs.get_room_member_handler()
 
@@ -221,12 +215,6 @@ class TestJoinsLimitedByPerRoomRateLimiter(FederatingHomeserverTestCase):
 
 
 class TestReplicatedJoinsLimitedByPerRoomRateLimiter(BaseMultiWorkerStreamTestCase):
-    servlets = [
-        admin.register_servlets,
-        relapse.rest.client.login.register_servlets,
-        relapse.rest.client.room.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.handler = hs.get_room_member_handler()
 
@@ -294,12 +282,6 @@ class TestReplicatedJoinsLimitedByPerRoomRateLimiter(BaseMultiWorkerStreamTestCa
 
 
 class RoomMemberMasterHandlerTestCase(HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        relapse.rest.client.login.register_servlets,
-        relapse.rest.client.room.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.handler = hs.get_room_member_handler()
         self.store = hs.get_datastores().main

--- a/tests/handlers/test_room_member.py
+++ b/tests/handlers/test_room_member.py
@@ -2,14 +2,11 @@ from unittest.mock import AsyncMock, patch
 
 from twisted.internet.testing import MemoryReactor
 
-import relapse.rest.client.login
-import relapse.rest.client.room
 from relapse.api.constants import EventTypes, Membership
 from relapse.api.errors import LimitExceededError, RelapseError
 from relapse.crypto.event_signing import add_hashes_and_signatures
 from relapse.events import FrozenEventV3
 from relapse.federation.federation_client import SendJoinResult
-from relapse.rest import admin
 from relapse.server import HomeServer
 from relapse.types import UserID, create_requester
 from relapse.util import Clock

--- a/tests/handlers/test_room_summary.py
+++ b/tests/handlers/test_room_summary.py
@@ -32,8 +32,6 @@ from relapse.api.room_versions import RoomVersions
 from relapse.events import make_event_from_dict
 from relapse.handlers.room_summary import _child_events_comparison_key, _RoomEntry
 from relapse.http.types import QueryParams
-from relapse.rest import admin
-from relapse.rest.client import login, room
 from relapse.server import HomeServer
 from relapse.types import JsonDict, UserID, create_requester
 from relapse.util import Clock

--- a/tests/handlers/test_room_summary.py
+++ b/tests/handlers/test_room_summary.py
@@ -114,12 +114,6 @@ class TestSpaceSummarySort(unittest.TestCase):
 
 
 class SpaceSummaryTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-    ]
-
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         self.mock_client = mock.Mock(spec=["get_json", "agent"])
         self.mock_client.get_json = mock.AsyncMock()
@@ -1030,12 +1024,6 @@ class SpaceSummaryTestCase(unittest.HomeserverTestCase):
 
 
 class RoomSummaryTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.hs = hs
         self.handler = self.hs.get_room_summary_handler()

--- a/tests/handlers/test_stats.py
+++ b/tests/handlers/test_stats.py
@@ -16,8 +16,6 @@ from typing import Any, cast
 
 from twisted.internet.testing import MemoryReactor
 
-from relapse.rest import admin
-from relapse.rest.client import login, room
 from relapse.server import HomeServer
 from relapse.storage.databases.main import stats
 from relapse.util import Clock

--- a/tests/handlers/test_stats.py
+++ b/tests/handlers/test_stats.py
@@ -31,12 +31,6 @@ EXPT_NUM_STATE_EVTS_IN_FRESH_PRIVATE_ROOM = 6
 
 
 class StatsRoomTests(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.store = hs.get_datastores().main
         self.handler = self.hs.get_stats_handler()

--- a/tests/handlers/test_sync.py
+++ b/tests/handlers/test_sync.py
@@ -20,8 +20,6 @@ from relapse.api.errors import Codes, ResourceLimitError
 from relapse.api.filtering import Filtering
 from relapse.api.room_versions import RoomVersions
 from relapse.handlers.sync import SyncConfig, SyncResult
-from relapse.rest import admin
-from relapse.rest.client import knock, login, room
 from relapse.server import HomeServer
 from relapse.types import UserID, create_requester
 from relapse.util import Clock

--- a/tests/handlers/test_sync.py
+++ b/tests/handlers/test_sync.py
@@ -33,13 +33,6 @@ import tests.utils
 class SyncTestCase(tests.unittest.HomeserverTestCase):
     """Tests Sync Handler."""
 
-    servlets = [
-        admin.register_servlets,
-        knock.register_servlets,
-        login.register_servlets,
-        room.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.sync_handler = self.hs.get_sync_handler()
         self.store = self.hs.get_datastores().main

--- a/tests/handlers/test_user_directory.py
+++ b/tests/handlers/test_user_directory.py
@@ -21,8 +21,6 @@ from relapse.api.constants import UserTypes
 from relapse.api.errors import RelapseError
 from relapse.api.room_versions import RoomVersion, RoomVersions
 from relapse.appservice import ApplicationService
-from relapse.rest import admin
-from relapse.rest.client import login, register, room, user_directory
 from relapse.server import HomeServer
 from relapse.storage.roommember import ProfileInfo
 from relapse.types import JsonDict, UserProfile, create_requester

--- a/tests/handlers/test_user_directory.py
+++ b/tests/handlers/test_user_directory.py
@@ -54,13 +54,6 @@ class UserDirectoryTestCase(unittest.HomeserverTestCase):
     tests/storage/test_user_directory.py.
     """
 
-    servlets = [
-        login.register_servlets,
-        admin.register_servlets,
-        register.register_servlets,
-        room.register_servlets,
-    ]
-
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         config = self.default_config()
         # Re-enables updating the user directory, as that function is needed below.
@@ -1057,13 +1050,6 @@ class UserDirectoryTestCase(unittest.HomeserverTestCase):
 
 
 class TestUserDirSearchDisabled(unittest.HomeserverTestCase):
-    servlets = [
-        user_directory.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-        admin.register_servlets,
-    ]
-
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         config = self.default_config()
         # Re-enables updating the user directory, as that function is needed below. It
@@ -1110,13 +1096,6 @@ class TestUserDirSearchDisabled(unittest.HomeserverTestCase):
 
 
 class UserDirectoryRemoteProfileTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        login.register_servlets,
-        admin.register_servlets,
-        register.register_servlets,
-        room.register_servlets,
-    ]
-
     def default_config(self) -> JsonDict:
         config = super().default_config()
         # Re-enables updating the user directory, as that functionality is needed below.

--- a/tests/http/test_servlet.py
+++ b/tests/http/test_servlet.py
@@ -20,6 +20,8 @@ from unittest.mock import Mock
 from pydantic import BaseModel
 
 from relapse.api.errors import Codes, RelapseError
+from relapse.config.server import HttpResourceConfig
+from relapse.http.server import JsonResource
 from relapse.http.servlet import (
     RestServlet,
     parse_json_object_from_request,
@@ -29,10 +31,12 @@ from relapse.http.servlet import (
 from relapse.http.site import RelapseRequest
 from relapse.server import HomeServer
 from relapse.types import JsonDict
+from relapse.util import Clock
 from relapse.util.cancellation import cancellable
 
 from tests import unittest
 from tests.http.server._base import test_disconnect
+from tests.server import TestHomeServer, ThreadedMemoryReactorClock
 
 
 def make_request(content: bytes | JsonDict) -> Mock:
@@ -129,12 +133,23 @@ class CancellableRestServlet(RestServlet):
         return HTTPStatus.OK, {"result": True}
 
 
+class CancellationTestHomeserver(TestHomeServer):
+    def resource_for_listener(
+        self, resources: list[HttpResourceConfig]
+    ) -> JsonResource:
+        resource = JsonResource(self)
+        CancellableRestServlet(self).register(resource)
+        return resource
+
+
 class TestRestServletCancellation(unittest.HomeserverTestCase):
     """Tests for `RestServlet` cancellation."""
 
-    servlets = [
-        lambda hs, http_server: CancellableRestServlet(hs).register(http_server)
-    ]
+    def make_homeserver(
+        self, reactor: ThreadedMemoryReactorClock, clock: Clock
+    ) -> HomeServer:
+        # Override to load different servlets.
+        return self.setup_test_homeserver(homeserver_to_use=CancellationTestHomeserver)
 
     def test_cancellable_disconnect(self) -> None:
         """Test that handlers with the `@cancellable` flag can be cancelled."""

--- a/tests/http/test_site.py
+++ b/tests/http/test_site.py
@@ -44,7 +44,7 @@ class RelapseRequestTestCase(HomeserverTestCase):
         protocol.makeConnection(transport)
 
         protocol.dataReceived(
-            b"POST / HTTP/1.1\r\n"
+            b"GET /_matrix/client/foo HTTP/1.1\r\n"
             b"Connection: close\r\n"
             b"Transfer-Encoding: chunked\r\n"
             b"\r\n"

--- a/tests/media/test_media_retention.py
+++ b/tests/media/test_media_retention.py
@@ -19,8 +19,6 @@ from matrix_common.types.mxc_uri import MXCUri
 
 from twisted.internet.testing import MemoryReactor
 
-from relapse.rest import admin
-from relapse.rest.client import login, register, room
 from relapse.server import HomeServer
 from relapse.types import UserID
 from relapse.util import Clock

--- a/tests/media/test_media_retention.py
+++ b/tests/media/test_media_retention.py
@@ -34,13 +34,6 @@ class MediaRetentionTestCase(unittest.HomeserverTestCase):
     ONE_DAY_IN_MS = 24 * 60 * 60 * 1000
     THIRTY_DAYS_IN_MS = 30 * ONE_DAY_IN_MS
 
-    servlets = [
-        room.register_servlets,
-        login.register_servlets,
-        register.register_servlets,
-        admin.register_servlets,
-    ]
-
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         # We need to be able to test advancing time in the homeserver, so we
         # replace the test homeserver's default clock with a MockClock, which

--- a/tests/media/test_media_storage.py
+++ b/tests/media/test_media_storage.py
@@ -223,7 +223,6 @@ class MediaRepoTests(unittest.HomeserverTestCase):
     test_image: ClassVar[_TestImage]
     hijack_auth = True
     user_id = "@test:user"
-    servlets = [media.register_servlets]
 
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         self.fetches: list[
@@ -716,12 +715,6 @@ EVIL_DATA_EXPERIMENT = b"Some evil data to trigger the experimental tuple API"
 
 
 class SpamCheckerTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        login.register_servlets,
-        admin.register_servlets,
-        media.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.user = self.register_user("user", "pass")
         self.tok = self.login("user", "pass")

--- a/tests/media/test_media_storage.py
+++ b/tests/media/test_media_storage.py
@@ -36,8 +36,6 @@ from relapse.media._base import FileInfo, ThumbnailInfo
 from relapse.media.filepath import MediaFilePaths
 from relapse.media.media_storage import MediaStorage, ReadableFileWrapper
 from relapse.media.storage_provider import FileStorageProviderBackend
-from relapse.rest import admin, media
-from relapse.rest.client import login
 from relapse.rest.media.thumbnail import ThumbnailServlet
 from relapse.server import HomeServer
 from relapse.types import JsonDict

--- a/tests/module_api/test_account_data_manager.py
+++ b/tests/module_api/test_account_data_manager.py
@@ -22,10 +22,6 @@ from tests.unittest import HomeserverTestCase
 
 
 class ModuleApiTestCase(HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-    ]
-
     def prepare(
         self, reactor: MemoryReactor, clock: Clock, homeserver: HomeServer
     ) -> None:

--- a/tests/module_api/test_account_data_manager.py
+++ b/tests/module_api/test_account_data_manager.py
@@ -14,7 +14,6 @@
 from twisted.internet.testing import MemoryReactor
 
 from relapse.api.errors import RelapseError
-from relapse.rest import admin
 from relapse.server import HomeServer
 from relapse.util import Clock
 

--- a/tests/module_api/test_api.py
+++ b/tests/module_api/test_api.py
@@ -50,15 +50,6 @@ class BaseModuleApiTestCase(HomeserverTestCase):
 
 
 class ModuleApiTestCase(BaseModuleApiTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        room.register_servlets,
-        presence.register_servlets,
-        profile.register_servlets,
-        notifications.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.store = hs.get_datastores().main
         self.module_api = hs.get_module_api()
@@ -824,13 +815,6 @@ class ModuleApiTestCase(BaseModuleApiTestCase):
 
 class ModuleApiWorkerTestCase(BaseModuleApiTestCase, BaseMultiWorkerStreamTestCase):
     """For testing ModuleApi functionality in a multi-worker setup"""
-
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        room.register_servlets,
-        presence.register_servlets,
-    ]
 
     def default_config(self) -> dict[str, Any]:
         conf = super().default_config()

--- a/tests/module_api/test_api.py
+++ b/tests/module_api/test_api.py
@@ -25,8 +25,6 @@ from relapse.handlers.device import DeviceHandler
 from relapse.handlers.presence import UserPresenceState
 from relapse.handlers.push_rules import InvalidRuleException
 from relapse.module_api import ModuleApi
-from relapse.rest import admin
-from relapse.rest.client import login, notifications, presence, profile, room
 from relapse.server import HomeServer
 from relapse.types import JsonDict, UserID, create_requester
 from relapse.util import Clock

--- a/tests/module_api/test_event_unsigned_addition.py
+++ b/tests/module_api/test_event_unsigned_addition.py
@@ -24,12 +24,6 @@ from tests.unittest import HomeserverTestCase
 
 
 class EventUnsignedAdditionTestCase(HomeserverTestCase):
-    servlets = [
-        room.register_servlets,
-        admin.register_servlets,
-        login.register_servlets,
-    ]
-
     def prepare(
         self, reactor: MemoryReactor, clock: Clock, homeserver: HomeServer
     ) -> None:

--- a/tests/module_api/test_event_unsigned_addition.py
+++ b/tests/module_api/test_event_unsigned_addition.py
@@ -14,8 +14,6 @@
 from twisted.internet.testing import MemoryReactor
 
 from relapse.events import EventBase
-from relapse.rest import admin
-from relapse.rest.client import login, room
 from relapse.server import HomeServer
 from relapse.types import JsonDict
 from relapse.util import Clock

--- a/tests/push/test_bulk_push_rule_evaluator.py
+++ b/tests/push/test_bulk_push_rule_evaluator.py
@@ -22,8 +22,6 @@ from twisted.internet.testing import MemoryReactor
 from relapse.api.constants import EventContentFields, RelationTypes
 from relapse.api.room_versions import RoomVersions
 from relapse.push.bulk_push_rule_evaluator import BulkPushRuleEvaluator
-from relapse.rest import admin
-from relapse.rest.client import login, register, room
 from relapse.server import HomeServer
 from relapse.types import JsonDict, create_requester
 from relapse.util import Clock

--- a/tests/push/test_bulk_push_rule_evaluator.py
+++ b/tests/push/test_bulk_push_rule_evaluator.py
@@ -32,13 +32,6 @@ from tests.unittest import HomeserverTestCase, override_config
 
 
 class TestBulkPushRuleEvaluator(HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-        register.register_servlets,
-    ]
-
     def prepare(
         self, reactor: MemoryReactor, clock: Clock, homeserver: HomeServer
     ) -> None:

--- a/tests/push/test_email.py
+++ b/tests/push/test_email.py
@@ -26,9 +26,6 @@ from twisted.internet.testing import MemoryReactor
 
 from relapse.api.errors import Codes, RelapseError
 from relapse.push.emailpusher import EmailPusher
-from relapse.rest import admin
-from relapse.rest.client import login, room
-from relapse.rest.relapse import client as relapse_client
 from relapse.server import HomeServer
 from relapse.util import Clock
 

--- a/tests/push/test_email.py
+++ b/tests/push/test_email.py
@@ -44,12 +44,6 @@ class _User:
 
 
 class EmailPusherTests(HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-        relapse_client.register_servlets,
-    ]
     hijack_auth = False
 
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:

--- a/tests/push/test_http.py
+++ b/tests/push/test_http.py
@@ -29,14 +29,6 @@ from tests.unittest import HomeserverTestCase, override_config
 
 
 class HTTPPusherTests(HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-        receipts.register_servlets,
-        push_rule.register_servlets,
-        pusher.register_servlets,
-    ]
     user_id = True
     hijack_auth = False
 

--- a/tests/push/test_http.py
+++ b/tests/push/test_http.py
@@ -19,8 +19,6 @@ from twisted.internet.testing import MemoryReactor
 
 from relapse.logging.context import make_deferred_yieldable
 from relapse.push import PusherConfig, PusherConfigException
-from relapse.rest import admin
-from relapse.rest.client import login, push_rule, pusher, receipts, room
 from relapse.server import HomeServer
 from relapse.types import JsonDict
 from relapse.util import Clock

--- a/tests/push/test_push_rule_evaluator.py
+++ b/tests/push/test_push_rule_evaluator.py
@@ -23,8 +23,6 @@ from relapse.events import FrozenEvent, make_event_from_dict
 from relapse.push.bulk_push_rule_evaluator import _flatten_dict
 from relapse.push.httppusher import tweaks_for_actions
 from relapse.relapse_rust.push import PushRuleEvaluator
-from relapse.rest import admin
-from relapse.rest.client import login, register, room
 from relapse.server import HomeServer
 from relapse.storage.databases.main.appservice import _make_exclusive_regex
 from relapse.types import JsonDict, JsonMapping, UserID

--- a/tests/push/test_push_rule_evaluator.py
+++ b/tests/push/test_push_rule_evaluator.py
@@ -546,13 +546,6 @@ class PushRuleEvaluatorTestCase(unittest.TestCase):
 class TestBulkPushRuleEvaluator(unittest.HomeserverTestCase):
     """Tests for the bulk push rule evaluator"""
 
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        register.register_servlets,
-        room.register_servlets,
-    ]
-
     def prepare(
         self, reactor: MemoryReactor, clock: Clock, homeserver: HomeServer
     ) -> None:
@@ -621,12 +614,6 @@ class TestBulkPushRuleEvaluator(unittest.HomeserverTestCase):
 
 
 class BulkPushRuleEvaluatorTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        room.register_servlets,
-    ]
-
     def prepare(
         self, reactor: MemoryReactor, clock: Clock, homeserver: HomeServer
     ) -> None:

--- a/tests/replication/_base.py
+++ b/tests/replication/_base.py
@@ -349,12 +349,15 @@ class BaseMultiWorkerStreamTestCase(unittest.HomeserverTestCase):
         store.db_pool._db_pool = self.database_pool._db_pool
 
         # Set up a resource for the worker
-        resource = self.create_test_resource(worker_hs)
-
+        listener_config = worker_hs.config.server.listeners[0]
+        assert listener_config.http_options is not None
+        resource = worker_hs.resource_for_listener(
+            listener_config.http_options.resources
+        )
         self._hs_to_site[worker_hs] = RelapseSite(
             logger_name="relapse.access.http.fake",
             site_tag=f"{worker_hs.config.server.server_name}-{worker_hs.get_instance_name()}",
-            config=worker_hs.config.server.listeners[0],
+            config=listener_config,
             resource=resource,
             server_version_string="1",
             max_request_body_size=8192,

--- a/tests/replication/_base.py
+++ b/tests/replication/_base.py
@@ -49,8 +49,6 @@ logger = logging.getLogger(__name__)
 class BaseStreamTestCase(unittest.HomeserverTestCase):
     """Base class for tests of the replication streams"""
 
-    servlets = [register_servlets]
-
     # hiredis is an optional dependency so we don't want to require it for running
     # the tests.
     if not hiredis:
@@ -233,8 +231,6 @@ class BaseMultiWorkerStreamTestCase(unittest.HomeserverTestCase):
     if not USE_POSTGRES_FOR_TESTS:
         # Redis replication only takes place on Postgres
         skip = "Requires Postgres"
-
-    servlets = [register_servlets]
 
     def default_config(self) -> dict[str, Any]:
         """

--- a/tests/replication/_base.py
+++ b/tests/replication/_base.py
@@ -23,7 +23,6 @@ from twisted.python.failure import Failure
 from relapse.app.generic_worker import GenericWorkerServer
 from relapse.config.workers import InstanceTcpLocationConfig, InstanceUnixLocationConfig
 from relapse.http.site import RelapseRequest, RelapseSite
-from relapse.replication.http import register_servlets
 from relapse.replication.tcp.client import ReplicationDataHandler
 from relapse.replication.tcp.handler import ReplicationCommandHandler
 from relapse.replication.tcp.protocol import (

--- a/tests/replication/http/test__base.py
+++ b/tests/replication/http/test__base.py
@@ -17,15 +17,18 @@ from http import HTTPStatus
 from twisted.web.server import Request
 
 from relapse.api.errors import Codes
-from relapse.http.server import HttpServer
+from relapse.config.server import HttpResourceConfig
+from relapse.http.server import JsonResource
 from relapse.replication.http import REPLICATION_PREFIX
 from relapse.replication.http._base import ReplicationEndpoint
 from relapse.server import HomeServer
 from relapse.types import JsonDict
+from relapse.util import Clock
 from relapse.util.cancellation import cancellable
 
 from tests import unittest
 from tests.http.server._base import test_disconnect
+from tests.server import TestHomeServer, ThreadedMemoryReactorClock
 
 
 class CancellableReplicationEndpoint(ReplicationEndpoint):
@@ -70,15 +73,24 @@ class UncancellableReplicationEndpoint(ReplicationEndpoint):
         return HTTPStatus.OK, {"result": True}
 
 
-def register_test_servlets(hs: HomeServer, http_server: HttpServer) -> None:
-    CancellableReplicationEndpoint(hs).register(http_server)
-    UncancellableReplicationEndpoint(hs).register(http_server)
+class CancellationTestHomeserver(TestHomeServer):
+    def resource_for_listener(
+        self, resources: list[HttpResourceConfig]
+    ) -> JsonResource:
+        resource = JsonResource(self)
+        CancellableReplicationEndpoint(self).register(resource)
+        UncancellableReplicationEndpoint(self).register(resource)
+        return resource
 
 
 class ReplicationEndpointCancellationTestCase(unittest.HomeserverTestCase):
     """Tests for `ReplicationEndpoint` cancellation."""
 
-    servlets = [register_test_servlets]
+    def make_homeserver(
+        self, reactor: ThreadedMemoryReactorClock, clock: Clock
+    ) -> HomeServer:
+        # Override to load different servlets.
+        return self.setup_test_homeserver(homeserver_to_use=CancellationTestHomeserver)
 
     def test_cancellable_disconnect(self) -> None:
         """Test that handlers with the `@cancellable` flag can be cancelled."""

--- a/tests/replication/tcp/streams/test_events.py
+++ b/tests/replication/tcp/streams/test_events.py
@@ -29,8 +29,6 @@ from relapse.replication.tcp.streams.events import (
     EventsStreamEventRow,
     EventsStreamRow,
 )
-from relapse.rest import admin
-from relapse.rest.client import login, room
 from relapse.server import HomeServer
 from relapse.util import Clock
 

--- a/tests/replication/tcp/streams/test_events.py
+++ b/tests/replication/tcp/streams/test_events.py
@@ -39,12 +39,6 @@ from tests.test_utils.event_injection import inject_event, inject_member_event
 
 
 class EventsStreamTestCase(BaseStreamTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        room.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         super().prepare(reactor, clock, hs)
         self.user_id = self.register_user("u1", "pass")

--- a/tests/replication/tcp/streams/test_partial_state.py
+++ b/tests/replication/tcp/streams/test_partial_state.py
@@ -19,7 +19,6 @@ from tests.replication._base import BaseMultiWorkerStreamTestCase
 
 
 class PartialStateStreamsTestCase(BaseMultiWorkerStreamTestCase):
-    servlets = [room.register_servlets]
     hijack_auth = True
     user_id = "@bob:test"
 

--- a/tests/replication/tcp/streams/test_partial_state.py
+++ b/tests/replication/tcp/streams/test_partial_state.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 from twisted.internet.defer import ensureDeferred
 
-from relapse.rest.client import room
-
 from tests.replication._base import BaseMultiWorkerStreamTestCase
 
 

--- a/tests/replication/tcp/streams/test_to_device.py
+++ b/tests/replication/tcp/streams/test_to_device.py
@@ -24,11 +24,6 @@ logger = logging.getLogger(__name__)
 
 
 class ToDeviceStreamTestCase(BaseStreamTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-    ]
-
     def test_to_device_stream(self) -> None:
         store = self.hs.get_datastores().main
 

--- a/tests/replication/tcp/streams/test_to_device.py
+++ b/tests/replication/tcp/streams/test_to_device.py
@@ -14,8 +14,6 @@
 import logging
 
 from relapse.replication.tcp.streams._base import _STREAM_UPDATE_TARGET_ROW_COUNT
-from relapse.rest import admin
-from relapse.rest.client import login
 from relapse.types import JsonDict
 
 from tests.replication._base import BaseStreamTestCase

--- a/tests/replication/test_auth.py
+++ b/tests/replication/test_auth.py
@@ -15,7 +15,6 @@ import logging
 
 from twisted.internet.testing import MemoryReactor
 
-from relapse.rest.client import register
 from relapse.server import HomeServer
 from relapse.util import Clock
 

--- a/tests/replication/test_auth.py
+++ b/tests/replication/test_auth.py
@@ -29,8 +29,6 @@ logger = logging.getLogger(__name__)
 class WorkerAuthenticationTestCase(BaseMultiWorkerStreamTestCase):
     """Test the authentication of HTTP calls between workers."""
 
-    servlets = [register.register_servlets] + BaseMultiWorkerStreamTestCase.servlets
-
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         config = self.default_config()
         # This isn't a real configuration option but is used to provide the main

--- a/tests/replication/test_auth.py
+++ b/tests/replication/test_auth.py
@@ -59,7 +59,7 @@ class WorkerAuthenticationTestCase(BaseMultiWorkerStreamTestCase):
             self.reactor,
             site,
             "POST",
-            "register",
+            "/_matrix/client/v3/register",
             {"username": "user", "type": "m.login.password", "password": "bar"},
         )
         self.assertEqual(channel_1.code, 401)
@@ -72,7 +72,7 @@ class WorkerAuthenticationTestCase(BaseMultiWorkerStreamTestCase):
             self.reactor,
             site,
             "POST",
-            "register",
+            "/_matrix/client/v3/register",
             {"auth": {"session": session, "type": "m.login.dummy"}},
         )
 

--- a/tests/replication/test_client_reader_shard.py
+++ b/tests/replication/test_client_reader_shard.py
@@ -38,7 +38,7 @@ class ClientReaderTestCase(BaseMultiWorkerStreamTestCase):
             self.reactor,
             site,
             "POST",
-            "register",
+            "/_matrix/client/v3/register",
             {"username": "user", "type": "m.login.password", "password": "bar"},
         )
         self.assertEqual(channel_1.code, 401)
@@ -51,7 +51,7 @@ class ClientReaderTestCase(BaseMultiWorkerStreamTestCase):
             self.reactor,
             site,
             "POST",
-            "register",
+            "/_matrix/client/v3/register",
             {"auth": {"session": session, "type": "m.login.dummy"}},
         )
         self.assertEqual(channel_2.code, 200)
@@ -69,7 +69,7 @@ class ClientReaderTestCase(BaseMultiWorkerStreamTestCase):
             self.reactor,
             site_1,
             "POST",
-            "register",
+            "/_matrix/client/v3/register",
             {"username": "user", "type": "m.login.password", "password": "bar"},
         )
         self.assertEqual(channel_1.code, 401)
@@ -83,7 +83,7 @@ class ClientReaderTestCase(BaseMultiWorkerStreamTestCase):
             self.reactor,
             site_2,
             "POST",
-            "register",
+            "/_matrix/client/v3/register",
             {"auth": {"session": session, "type": "m.login.dummy"}},
         )
         self.assertEqual(channel_2.code, 200)

--- a/tests/replication/test_client_reader_shard.py
+++ b/tests/replication/test_client_reader_shard.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 import logging
 
-from relapse.rest.client import register
-
 from tests.replication._base import BaseMultiWorkerStreamTestCase
 from tests.server import make_request
 

--- a/tests/replication/test_client_reader_shard.py
+++ b/tests/replication/test_client_reader_shard.py
@@ -24,8 +24,6 @@ logger = logging.getLogger(__name__)
 class ClientReaderTestCase(BaseMultiWorkerStreamTestCase):
     """Test using one or more generic workers for registration."""
 
-    servlets = [register.register_servlets] + BaseMultiWorkerStreamTestCase.servlets
-
     def _get_worker_hs_config(self) -> dict:
         config = self.default_config()
         config["worker_app"] = "relapse.app.generic_worker"

--- a/tests/replication/test_federation_sender_shard.py
+++ b/tests/replication/test_federation_sender_shard.py
@@ -38,12 +38,6 @@ class FederationSenderTestCase(BaseMultiWorkerStreamTestCase):
     updating 'federation_sender_instances'.
     """
 
-    servlets = [
-        login.register_servlets,
-        admin.register_servlets,
-        room.register_servlets,
-    ]
-
     def setUp(self) -> None:
         super().setUp()
 

--- a/tests/replication/test_federation_sender_shard.py
+++ b/tests/replication/test_federation_sender_shard.py
@@ -20,8 +20,6 @@ from relapse.api.constants import EventTypes, Membership
 from relapse.events.builder import EventBuilderFactory
 from relapse.handlers.typing import TypingWriterHandler
 from relapse.http.federation.matrix_federation_agent import MatrixFederationAgent
-from relapse.rest import admin
-from relapse.rest.client import login, room
 from relapse.types import UserID, create_requester
 
 from tests.replication._base import BaseMultiWorkerStreamTestCase

--- a/tests/replication/test_module_cache_invalidation.py
+++ b/tests/replication/test_module_cache_invalidation.py
@@ -35,10 +35,6 @@ class TestCache:
 
 
 class ModuleCacheInvalidationTestCase(BaseMultiWorkerStreamTestCase):
-    servlets = [
-        admin.register_servlets,
-    ]
-
     def test_module_cache_full_invalidation(self) -> None:
         main_cache = TestCache()
         self.hs.get_module_api().register_cached_function(main_cache.cached_function)

--- a/tests/replication/test_module_cache_invalidation.py
+++ b/tests/replication/test_module_cache_invalidation.py
@@ -14,7 +14,6 @@
 import logging
 
 from relapse.module_api import cached
-from relapse.rest import admin
 
 from tests.replication._base import BaseMultiWorkerStreamTestCase
 

--- a/tests/replication/test_multi_media_repo.py
+++ b/tests/replication/test_multi_media_repo.py
@@ -41,12 +41,6 @@ test_server_connection_factory: TestServerTLSConnectionFactory | None = None
 class MediaRepoShardTestCase(BaseMultiWorkerStreamTestCase):
     """Checks running multiple media repos work correctly."""
 
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        media.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.user_id = self.register_user("user", "pass")
         self.access_token = self.login("user", "pass")

--- a/tests/replication/test_multi_media_repo.py
+++ b/tests/replication/test_multi_media_repo.py
@@ -19,8 +19,6 @@ from twisted.internet.testing import MemoryReactor
 from twisted.web.http import HTTPChannel
 from twisted.web.server import Request
 
-from relapse.rest import admin, media
-from relapse.rest.client import login
 from relapse.server import HomeServer
 from relapse.util import Clock
 

--- a/tests/replication/test_pusher_shard.py
+++ b/tests/replication/test_pusher_shard.py
@@ -17,8 +17,6 @@ from unittest.mock import Mock
 from twisted.internet import defer
 from twisted.internet.testing import MemoryReactor
 
-from relapse.rest import admin
-from relapse.rest.client import login, room
 from relapse.server import HomeServer
 from relapse.util import Clock
 

--- a/tests/replication/test_pusher_shard.py
+++ b/tests/replication/test_pusher_shard.py
@@ -30,12 +30,6 @@ logger = logging.getLogger(__name__)
 class PusherShardTestCase(BaseMultiWorkerStreamTestCase):
     """Checks pusher sharding works"""
 
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         # Register a user who sends a message that we'll get notified about
         self.other_user_id = self.register_user("otheruser", "pass")

--- a/tests/replication/test_sharded_event_persister.py
+++ b/tests/replication/test_sharded_event_persister.py
@@ -31,13 +31,6 @@ logger = logging.getLogger(__name__)
 class EventPersisterShardTestCase(BaseMultiWorkerStreamTestCase):
     """Checks event persisting sharding works"""
 
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-        sync.register_servlets,
-    ] + BaseMultiWorkerStreamTestCase.servlets
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         # Register a user who sends a message that we'll get notified about
         self.other_user_id = self.register_user("otheruser", "pass")

--- a/tests/replication/test_sharded_event_persister.py
+++ b/tests/replication/test_sharded_event_persister.py
@@ -16,8 +16,6 @@ from unittest.mock import patch
 
 from twisted.internet.testing import MemoryReactor
 
-from relapse.rest import admin
-from relapse.rest.client import login, room, sync
 from relapse.server import HomeServer
 from relapse.storage.util.id_generators import MultiWriterIdGenerator
 from relapse.util import Clock

--- a/tests/replication/test_sharded_receipts.py
+++ b/tests/replication/test_sharded_receipts.py
@@ -32,14 +32,6 @@ logger = logging.getLogger(__name__)
 class ReceiptsShardTestCase(BaseMultiWorkerStreamTestCase):
     """Checks receipts sharding works"""
 
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-        sync.register_servlets,
-        receipts.register_servlets,
-    ] + BaseMultiWorkerStreamTestCase.servlets
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         # Register a user who sends a message that we'll get notified about
         self.other_user_id = self.register_user("otheruser", "pass")

--- a/tests/replication/test_sharded_receipts.py
+++ b/tests/replication/test_sharded_receipts.py
@@ -16,8 +16,6 @@ import logging
 from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import ReceiptTypes
-from relapse.rest import admin
-from relapse.rest.client import login, receipts, room, sync
 from relapse.server import HomeServer
 from relapse.storage.util.id_generators import MultiWriterIdGenerator
 from relapse.types import StreamToken

--- a/tests/replication/test_sharded_receipts.py
+++ b/tests/replication/test_sharded_receipts.py
@@ -86,7 +86,7 @@ class ReceiptsShardTestCase(BaseMultiWorkerStreamTestCase):
             reactor=self.reactor,
             site=worker1_site,
             method="POST",
-            path=f"/rooms/{room_id}/receipt/{ReceiptTypes.READ}/{event_id}",
+            path=f"/_matrix/client/v3/rooms/{room_id}/receipt/{ReceiptTypes.READ}/{event_id}",
             access_token=access_token,
             content={},
         )
@@ -100,7 +100,7 @@ class ReceiptsShardTestCase(BaseMultiWorkerStreamTestCase):
             reactor=self.reactor,
             site=worker2_site,
             method="POST",
-            path=f"/rooms/{room_id}/receipt/{ReceiptTypes.READ}/{event_id}",
+            path=f"/_matrix/client/v3/rooms/{room_id}/receipt/{ReceiptTypes.READ}/{event_id}",
             access_token=access_token,
             content={},
         )
@@ -172,7 +172,7 @@ class ReceiptsShardTestCase(BaseMultiWorkerStreamTestCase):
             reactor=self.reactor,
             site=worker1_site,
             method="POST",
-            path=f"/rooms/{room_id}/receipt/{ReceiptTypes.READ}/{first_event}",
+            path=f"/_matrix/client/v3/rooms/{room_id}/receipt/{ReceiptTypes.READ}/{first_event}",
             access_token=access_token,
             content={},
         )
@@ -219,7 +219,7 @@ class ReceiptsShardTestCase(BaseMultiWorkerStreamTestCase):
             reactor=self.reactor,
             site=worker2_site,
             method="POST",
-            path=f"/rooms/{room_id}/receipt/{ReceiptTypes.READ}/{second_event}",
+            path=f"/_matrix/client/v3/rooms/{room_id}/receipt/{ReceiptTypes.READ}/{second_event}",
             access_token=access_token,
             content={},
         )

--- a/tests/rest/admin/test_admin.py
+++ b/tests/rest/admin/test_admin.py
@@ -18,9 +18,6 @@ from parameterized import parameterized
 
 from twisted.internet.testing import MemoryReactor
 
-from relapse.rest import admin, media
-from relapse.rest.admin import VersionServlet
-from relapse.rest.client import login, room
 from relapse.server import HomeServer
 from relapse.util import Clock
 

--- a/tests/rest/admin/test_admin.py
+++ b/tests/rest/admin/test_admin.py
@@ -31,8 +31,6 @@ from tests.test_utils import SMALL_PNG
 class VersionTestCase(unittest.HomeserverTestCase):
     url = "/_relapse/admin/v1/server_version"
 
-    servlets = [lambda hs, http_server: VersionServlet(hs).register(http_server)]
-
     def test_version_string(self) -> None:
         channel = self.make_request("GET", self.url)
 
@@ -42,14 +40,6 @@ class VersionTestCase(unittest.HomeserverTestCase):
 
 class QuarantineMediaTestCase(unittest.HomeserverTestCase):
     """Test /quarantine_media admin API."""
-
-    servlets = [
-        admin.register_servlets,
-        admin.register_servlets_for_media_repo,
-        login.register_servlets,
-        room.register_servlets,
-        media.register_servlets,
-    ]
 
     def _ensure_quarantined(
         self, admin_user_tok: str, server_and_media_id: str
@@ -277,12 +267,6 @@ class QuarantineMediaTestCase(unittest.HomeserverTestCase):
 
 
 class PurgeHistoryTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        room.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.admin_user = self.register_user("admin", "pass", admin=True)
         self.admin_user_tok = self.login("admin", "pass")
@@ -325,11 +309,6 @@ class PurgeHistoryTestCase(unittest.HomeserverTestCase):
 
 
 class ExperimentalFeaturesTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.admin_user = self.register_user("admin", "pass", admin=True)
         self.admin_user_tok = self.login("admin", "pass")

--- a/tests/rest/admin/test_background_updates.py
+++ b/tests/rest/admin/test_background_updates.py
@@ -18,8 +18,6 @@ from parameterized import parameterized
 from twisted.internet.testing import MemoryReactor
 
 from relapse.api.errors import Codes
-from relapse.rest import admin
-from relapse.rest.client import login
 from relapse.server import HomeServer
 from relapse.storage.background_updates import BackgroundUpdater
 from relapse.types import JsonDict

--- a/tests/rest/admin/test_background_updates.py
+++ b/tests/rest/admin/test_background_updates.py
@@ -29,11 +29,6 @@ from tests import unittest
 
 
 class BackgroundUpdatesTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.store = hs.get_datastores().main
         self.admin_user = self.register_user("admin", "pass", admin=True)

--- a/tests/rest/admin/test_device.py
+++ b/tests/rest/admin/test_device.py
@@ -19,8 +19,6 @@ from twisted.internet.testing import MemoryReactor
 
 from relapse.api.errors import Codes
 from relapse.handlers.device import MAX_DEVICE_DISPLAY_NAME_LEN, DeviceHandler
-from relapse.rest import admin
-from relapse.rest.client import login
 from relapse.server import HomeServer
 from relapse.util import Clock
 

--- a/tests/rest/admin/test_device.py
+++ b/tests/rest/admin/test_device.py
@@ -28,11 +28,6 @@ from tests import unittest
 
 
 class DeviceRestTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         handler = hs.get_device_handler()
         assert isinstance(handler, DeviceHandler)
@@ -276,11 +271,6 @@ class DeviceRestTestCase(unittest.HomeserverTestCase):
 
 
 class DevicesRestTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.admin_user = self.register_user("admin", "pass", admin=True)
         self.admin_user_tok = self.login("admin", "pass")
@@ -399,11 +389,6 @@ class DevicesRestTestCase(unittest.HomeserverTestCase):
 
 
 class DeleteDevicesRestTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.handler = hs.get_device_handler()
 

--- a/tests/rest/admin/test_event_reports.py
+++ b/tests/rest/admin/test_event_reports.py
@@ -15,8 +15,6 @@
 from twisted.internet.testing import MemoryReactor
 
 from relapse.api.errors import Codes
-from relapse.rest import admin
-from relapse.rest.client import login, report_event, room
 from relapse.server import HomeServer
 from relapse.types import JsonDict
 from relapse.util import Clock

--- a/tests/rest/admin/test_event_reports.py
+++ b/tests/rest/admin/test_event_reports.py
@@ -25,13 +25,6 @@ from tests import unittest
 
 
 class EventReportsTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        room.register_servlets,
-        report_event.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.admin_user = self.register_user("admin", "pass", admin=True)
         self.admin_user_tok = self.login("admin", "pass")
@@ -441,13 +434,6 @@ class EventReportsTestCase(unittest.HomeserverTestCase):
 
 
 class EventReportDetailTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        room.register_servlets,
-        report_event.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.admin_user = self.register_user("admin", "pass", admin=True)
         self.admin_user_tok = self.login("admin", "pass")
@@ -601,11 +587,6 @@ class EventReportDetailTestCase(unittest.HomeserverTestCase):
 
 
 class DeleteEventReportTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self._store = hs.get_datastores().main
 

--- a/tests/rest/admin/test_federation.py
+++ b/tests/rest/admin/test_federation.py
@@ -17,8 +17,6 @@ from parameterized import parameterized
 from twisted.internet.testing import MemoryReactor
 
 from relapse.api.errors import Codes
-from relapse.rest import admin
-from relapse.rest.client import login, room
 from relapse.server import HomeServer
 from relapse.types import JsonDict
 from relapse.util import Clock

--- a/tests/rest/admin/test_federation.py
+++ b/tests/rest/admin/test_federation.py
@@ -27,11 +27,6 @@ from tests import unittest
 
 
 class FederationTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.store = hs.get_datastores().main
         self.register_user("admin", "pass", admin=True)
@@ -527,12 +522,6 @@ class FederationTestCase(unittest.HomeserverTestCase):
 
 
 class DestinationMembershipTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        room.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.store = hs.get_datastores().main
         self.admin_user = self.register_user("admin", "pass", admin=True)

--- a/tests/rest/admin/test_jwks.py
+++ b/tests/rest/admin/test_jwks.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 
-
 from tests.unittest import HomeserverTestCase, override_config, skip_unless
 from tests.utils import HAS_AUTHLIB
 

--- a/tests/rest/admin/test_jwks.py
+++ b/tests/rest/admin/test_jwks.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 
-from relapse.rest.relapse import client as relapse_client
 
 from tests.unittest import HomeserverTestCase, override_config, skip_unless
 from tests.utils import HAS_AUTHLIB

--- a/tests/rest/admin/test_jwks.py
+++ b/tests/rest/admin/test_jwks.py
@@ -23,8 +23,6 @@ from tests.utils import HAS_AUTHLIB
 class JWKSTestCase(HomeserverTestCase):
     """Test /_relapse/jwks JWKS data."""
 
-    servlets = [relapse_client.register_servlets]
-
     def test_empty_jwks(self) -> None:
         """Test that the JWKS endpoint is not present by default."""
         channel = self.make_request("GET", "/_relapse/jwks")

--- a/tests/rest/admin/test_media.py
+++ b/tests/rest/admin/test_media.py
@@ -32,16 +32,7 @@ VALID_TIMESTAMP = 1609459200000  # 2021-01-01 in milliseconds
 INVALID_TIMESTAMP_IN_S = 1893456000  # 2030-01-01 in seconds
 
 
-class _AdminMediaTests(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        admin.register_servlets_for_media_repo,
-        login.register_servlets,
-        media.register_servlets,
-    ]
-
-
-class DeleteMediaByIDTestCase(_AdminMediaTests):
+class DeleteMediaByIDTestCase(unittest.HomeserverTestCase):
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.server_name = hs.hostname
 
@@ -184,12 +175,7 @@ class DeleteMediaByIDTestCase(_AdminMediaTests):
         self.assertFalse(os.path.exists(local_path))
 
 
-class DeleteMediaByDateSizeTestCase(_AdminMediaTests):
-    servlets = _AdminMediaTests.servlets + [
-        profile.register_servlets,
-        room.register_servlets,
-    ]
-
+class DeleteMediaByDateSizeTestCase(unittest.HomeserverTestCase):
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.server_name = hs.hostname
 
@@ -567,7 +553,7 @@ class DeleteMediaByDateSizeTestCase(_AdminMediaTests):
             self.assertFalse(os.path.exists(local_path))
 
 
-class QuarantineMediaByIDTestCase(_AdminMediaTests):
+class QuarantineMediaByIDTestCase(unittest.HomeserverTestCase):
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.store = hs.get_datastores().main
         self.server_name = hs.hostname
@@ -685,7 +671,7 @@ class QuarantineMediaByIDTestCase(_AdminMediaTests):
         self.assertFalse(media_info.quarantined_by)
 
 
-class ProtectMediaByIDTestCase(_AdminMediaTests):
+class ProtectMediaByIDTestCase(unittest.HomeserverTestCase):
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.store = hs.get_datastores().main
 
@@ -770,12 +756,7 @@ class ProtectMediaByIDTestCase(_AdminMediaTests):
         self.assertFalse(media_info.safe_from_quarantine)
 
 
-class PurgeMediaCacheTestCase(_AdminMediaTests):
-    servlets = _AdminMediaTests.servlets + [
-        profile.register_servlets,
-        room.register_servlets,
-    ]
-
+class PurgeMediaCacheTestCase(unittest.HomeserverTestCase):
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.server_name = hs.hostname
 

--- a/tests/rest/admin/test_media.py
+++ b/tests/rest/admin/test_media.py
@@ -20,8 +20,6 @@ from twisted.internet.testing import MemoryReactor
 
 from relapse.api.errors import Codes
 from relapse.media.filepath import MediaFilePaths
-from relapse.rest import admin, media
-from relapse.rest.client import login, profile, room
 from relapse.server import HomeServer
 from relapse.util import Clock
 

--- a/tests/rest/admin/test_registration_tokens.py
+++ b/tests/rest/admin/test_registration_tokens.py
@@ -17,8 +17,6 @@ import string
 from twisted.internet.testing import MemoryReactor
 
 from relapse.api.errors import Codes
-from relapse.rest import admin
-from relapse.rest.client import login
 from relapse.server import HomeServer
 from relapse.util import Clock
 

--- a/tests/rest/admin/test_registration_tokens.py
+++ b/tests/rest/admin/test_registration_tokens.py
@@ -26,11 +26,6 @@ from tests import unittest
 
 
 class ManageRegistrationTokensTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.store = hs.get_datastores().main
         self.admin_user = self.register_user("admin", "pass", admin=True)

--- a/tests/rest/admin/test_room.py
+++ b/tests/rest/admin/test_room.py
@@ -43,16 +43,6 @@ ONE_HOUR_IN_S = 3600
 
 
 class DeleteRoomTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        events.register_servlets,
-        room.register_servlets,
-        knock.register_servlets,
-        sync.register_servlets,
-        room.register_deprecated_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.event_creation_handler = hs.get_event_creation_handler()
         self.task_scheduler = hs.get_task_scheduler()
@@ -526,14 +516,6 @@ class DeleteRoomTestCase(unittest.HomeserverTestCase):
 
 
 class DeleteRoomV2TestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        events.register_servlets,
-        room.register_servlets,
-        room.register_deprecated_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.event_creation_handler = hs.get_event_creation_handler()
         self.task_scheduler = hs.get_task_scheduler()
@@ -1263,13 +1245,6 @@ class DeleteRoomV2TestCase(unittest.HomeserverTestCase):
 class RoomTestCase(unittest.HomeserverTestCase):
     """Test /room admin API."""
 
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        room.register_servlets,
-        directory.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         # Create user
         self.admin_user = self.register_user("admin", "pass", admin=True)
@@ -1976,12 +1951,6 @@ class RoomTestCase(unittest.HomeserverTestCase):
 
 
 class RoomMessagesTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        room.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.admin_user = self.register_user("admin", "pass", admin=True)
         self.admin_user_tok = self.login("admin", "pass")
@@ -2162,12 +2131,6 @@ class RoomMessagesTestCase(unittest.HomeserverTestCase):
 
 
 class JoinAliasRoomTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.admin_user = self.register_user("admin", "pass", admin=True)
         self.admin_user_tok = self.login("admin", "pass")
@@ -2496,12 +2459,6 @@ class JoinAliasRoomTestCase(unittest.HomeserverTestCase):
 
 
 class MakeRoomAdminTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.admin_user = self.register_user("admin", "pass", admin=True)
         self.admin_user_tok = self.login("admin", "pass")
@@ -2629,12 +2586,6 @@ class MakeRoomAdminTestCase(unittest.HomeserverTestCase):
 
 
 class BlockRoomTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self._store = hs.get_datastores().main
 

--- a/tests/rest/admin/test_room.py
+++ b/tests/rest/admin/test_room.py
@@ -27,8 +27,6 @@ from relapse.handlers.pagination import (
     PURGE_ROOM_ACTION_NAME,
     SHUTDOWN_AND_PURGE_ROOM_ACTION_NAME,
 )
-from relapse.rest import admin
-from relapse.rest.client import directory, events, knock, login, room, sync
 from relapse.server import HomeServer
 from relapse.types import UserID
 from relapse.util import Clock

--- a/tests/rest/admin/test_server_notice.py
+++ b/tests/rest/admin/test_server_notice.py
@@ -16,8 +16,6 @@ from collections.abc import Sequence
 from twisted.internet.testing import MemoryReactor
 
 from relapse.api.errors import Codes
-from relapse.rest import admin
-from relapse.rest.client import login, room, sync
 from relapse.server import HomeServer
 from relapse.storage.roommember import RoomsForUser
 from relapse.types import JsonDict

--- a/tests/rest/admin/test_server_notice.py
+++ b/tests/rest/admin/test_server_notice.py
@@ -29,13 +29,6 @@ from tests.unittest import override_config
 
 
 class ServerNoticeTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        room.register_servlets,
-        sync.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.store = hs.get_datastores().main
         self.room_shutdown_handler = hs.get_room_shutdown_handler()

--- a/tests/rest/admin/test_statistics.py
+++ b/tests/rest/admin/test_statistics.py
@@ -16,8 +16,6 @@
 from twisted.internet.testing import MemoryReactor
 
 from relapse.api.errors import Codes
-from relapse.rest import admin, media
-from relapse.rest.client import login
 from relapse.server import HomeServer
 from relapse.types import JsonDict
 from relapse.util import Clock

--- a/tests/rest/admin/test_statistics.py
+++ b/tests/rest/admin/test_statistics.py
@@ -27,12 +27,6 @@ from tests.test_utils import SMALL_PNG
 
 
 class UserMediaStatisticsTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        media.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.admin_user = self.register_user("admin", "pass", admin=True)
         self.admin_user_tok = self.login("admin", "pass")

--- a/tests/rest/admin/test_user.py
+++ b/tests/rest/admin/test_user.py
@@ -49,11 +49,6 @@ from tests.unittest import override_config
 
 
 class UserRegisterTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        profile.register_servlets,
-    ]
-
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         self.url = "/_relapse/admin/v1/register"
 
@@ -460,11 +455,6 @@ class UserRegisterTestCase(unittest.HomeserverTestCase):
 
 
 class UsersListTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        room.register_servlets,
-    ]
     url = "/_relapse/admin/v2/users"
 
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
@@ -1244,12 +1234,6 @@ class UserDevicesTestCase(unittest.HomeserverTestCase):
     Tests user device management-related Admin APIs.
     """
 
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        sync.register_servlets,
-    ]
-
     def prepare(
         self, reactor: MemoryReactor, clock: Clock, homeserver: HomeServer
     ) -> None:
@@ -1330,11 +1314,6 @@ class UserDevicesTestCase(unittest.HomeserverTestCase):
 
 
 class DeactivateAccountTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.store = hs.get_datastores().main
 
@@ -1607,14 +1586,6 @@ class DeactivateAccountTestCase(unittest.HomeserverTestCase):
 
 
 class UserRestTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        sync.register_servlets,
-        register.register_servlets,
-        user_directory.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.store = hs.get_datastores().main
         self.auth_handler = hs.get_auth_handler()
@@ -3132,12 +3103,6 @@ class UserRestTestCase(unittest.HomeserverTestCase):
 
 
 class UserMembershipRestTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        room.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.admin_user = self.register_user("admin", "pass", admin=True)
         self.admin_user_tok = self.login("admin", "pass")
@@ -3289,11 +3254,6 @@ class UserMembershipRestTestCase(unittest.HomeserverTestCase):
 
 
 class PushersRestTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.store = hs.get_datastores().main
 
@@ -3417,12 +3377,6 @@ class PushersRestTestCase(unittest.HomeserverTestCase):
 
 
 class UserMediaRestTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        media.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.store = hs.get_datastores().main
         self.filepaths = MediaFilePaths(hs.config.media.media_store_path)
@@ -3985,15 +3939,6 @@ class UserMediaRestTestCase(unittest.HomeserverTestCase):
 class UserTokenRestTestCase(unittest.HomeserverTestCase):
     """Test for /_relapse/admin/v1/users/<user>/login"""
 
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        sync.register_servlets,
-        room.register_servlets,
-        devices.register_servlets,
-        logout.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.store = hs.get_datastores().main
 
@@ -4213,11 +4158,6 @@ class UserTokenRestTestCase(unittest.HomeserverTestCase):
 
 
 class ShadowBanRestTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.store = hs.get_datastores().main
 
@@ -4293,11 +4233,6 @@ class ShadowBanRestTestCase(unittest.HomeserverTestCase):
 
 
 class RateLimitTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.store = hs.get_datastores().main
 
@@ -4515,11 +4450,6 @@ class RateLimitTestCase(unittest.HomeserverTestCase):
 
 
 class AccountDataTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.store = hs.get_datastores().main
 
@@ -4604,11 +4534,6 @@ class AccountDataTestCase(unittest.HomeserverTestCase):
 
 
 class UsersByExternalIdTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.store = hs.get_datastores().main
 
@@ -4690,11 +4615,6 @@ class UsersByExternalIdTestCase(unittest.HomeserverTestCase):
 
 
 class UsersByThreePidTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.store = hs.get_datastores().main
 
@@ -4784,11 +4704,6 @@ class UsersByThreePidTestCase(unittest.HomeserverTestCase):
 
 
 class AllowCrossSigningReplacementTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-    ]
-
     @staticmethod
     def url(user: str) -> str:
         template = (

--- a/tests/rest/admin/test_user.py
+++ b/tests/rest/admin/test_user.py
@@ -27,17 +27,6 @@ from relapse.api.constants import ApprovalNoticeMedium, LoginType, UserTypes
 from relapse.api.errors import Codes, HttpResponseException, ResourceLimitError
 from relapse.api.room_versions import RoomVersions
 from relapse.media.filepath import MediaFilePaths
-from relapse.rest import admin, media
-from relapse.rest.client import (
-    devices,
-    login,
-    logout,
-    profile,
-    register,
-    room,
-    sync,
-    user_directory,
-)
 from relapse.server import HomeServer
 from relapse.storage.databases.main.client_ips import LAST_SEEN_GRANULARITY
 from relapse.types import JsonDict, UserID, create_requester

--- a/tests/rest/admin/test_username_available.py
+++ b/tests/rest/admin/test_username_available.py
@@ -15,8 +15,6 @@
 from twisted.internet.testing import MemoryReactor
 
 from relapse.api.errors import Codes, RelapseError
-from relapse.rest import admin
-from relapse.rest.client import login
 from relapse.server import HomeServer
 from relapse.util import Clock
 

--- a/tests/rest/admin/test_username_available.py
+++ b/tests/rest/admin/test_username_available.py
@@ -24,10 +24,6 @@ from tests import unittest
 
 
 class UsernameAvailableTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-    ]
     url = "/_relapse/admin/v1/username_available"
 
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:

--- a/tests/rest/client/test_account.py
+++ b/tests/rest/client/test_account.py
@@ -23,9 +23,6 @@ from twisted.internet.testing import MemoryReactor
 from relapse.api.constants import LoginType, Membership
 from relapse.api.errors import Codes, HttpResponseException
 from relapse.appservice import ApplicationService
-from relapse.rest import admin
-from relapse.rest.client import account, login, register, room
-from relapse.rest.relapse.client.password_reset import PasswordResetSubmitTokenServlet
 from relapse.server import HomeServer
 from relapse.storage._base import db_to_json
 from relapse.types import JsonDict

--- a/tests/rest/client/test_account.py
+++ b/tests/rest/client/test_account.py
@@ -36,16 +36,6 @@ from tests.unittest import override_config
 
 
 class PasswordResetTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        account.register_servlets,
-        admin.register_servlets,
-        register.register_servlets,
-        login.register_servlets,
-        lambda hs, http_server: PasswordResetSubmitTokenServlet(hs).register(
-            http_server
-        ),
-    ]
-
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         config = self.default_config()
 
@@ -415,13 +405,6 @@ class PasswordResetTestCase(unittest.HomeserverTestCase):
 
 
 class DeactivateTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        account.register_servlets,
-        room.register_servlets,
-    ]
-
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         self.hs = self.setup_test_homeserver()
         return self.hs
@@ -660,13 +643,6 @@ class DeactivateTestCase(unittest.HomeserverTestCase):
 
 
 class WhoamiTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        account.register_servlets,
-        register.register_servlets,
-    ]
-
     def default_config(self) -> dict[str, Any]:
         config = super().default_config()
         config["allow_guest_access"] = True
@@ -736,12 +712,6 @@ class WhoamiTestCase(unittest.HomeserverTestCase):
 
 
 class ThreepidEmailRestTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        account.register_servlets,
-        login.register_servlets,
-        admin.register_servlets,
-    ]
-
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         config = self.default_config()
 

--- a/tests/rest/client/test_account_data.py
+++ b/tests/rest/client/test_account_data.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 from unittest.mock import AsyncMock
 
-from relapse.rest import admin
-from relapse.rest.client import account_data, login, room
-
 from tests import unittest
 
 

--- a/tests/rest/client/test_account_data.py
+++ b/tests/rest/client/test_account_data.py
@@ -20,13 +20,6 @@ from tests import unittest
 
 
 class AccountDataTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        room.register_servlets,
-        account_data.register_servlets,
-    ]
-
     def test_on_account_data_updated_callback(self) -> None:
         """Tests that the on_account_data_updated module callback is called correctly when
         a user's account data changes.

--- a/tests/rest/client/test_auth.py
+++ b/tests/rest/client/test_auth.py
@@ -22,9 +22,6 @@ from twisted.internet.testing import MemoryReactor
 from relapse.api.constants import ApprovalNoticeMedium, LoginType
 from relapse.api.errors import Codes, RelapseError
 from relapse.handlers.ui_auth.checkers import UserInteractiveAuthChecker
-from relapse.rest import admin
-from relapse.rest.client import account, auth, devices, login, logout, register
-from relapse.rest.relapse import client as relapse_client
 from relapse.server import HomeServer
 from relapse.storage.database import LoggingTransaction
 from relapse.types import JsonDict, UserID

--- a/tests/rest/client/test_auth.py
+++ b/tests/rest/client/test_auth.py
@@ -51,10 +51,6 @@ class DummyRecaptchaChecker(UserInteractiveAuthChecker):
 
 
 class FallbackAuthTests(unittest.HomeserverTestCase):
-    servlets = [
-        auth.register_servlets,
-        register.register_servlets,
-    ]
     hijack_auth = False
 
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
@@ -162,15 +158,6 @@ class FallbackAuthTests(unittest.HomeserverTestCase):
 
 
 class UIAuthTests(unittest.HomeserverTestCase):
-    servlets = [
-        auth.register_servlets,
-        devices.register_servlets,
-        login.register_servlets,
-        admin.register_servlets,
-        register.register_servlets,
-        relapse_client.register_servlets,
-    ]
-
     def default_config(self) -> dict[str, Any]:
         config = super().default_config()
 
@@ -609,14 +596,6 @@ class UIAuthTests(unittest.HomeserverTestCase):
 
 
 class RefreshAuthTests(unittest.HomeserverTestCase):
-    servlets = [
-        auth.register_servlets,
-        account.register_servlets,
-        login.register_servlets,
-        logout.register_servlets,
-        admin.register_servlets,
-        register.register_servlets,
-    ]
     hijack_auth = False
 
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
@@ -1195,12 +1174,6 @@ def oidc_config(
 
 @skip_unless(HAS_OIDC, "Requires OIDC")
 class OidcBackchannelLogoutTests(unittest.HomeserverTestCase):
-    servlets = [
-        account.register_servlets,
-        login.register_servlets,
-        relapse_client.register_servlets,
-    ]
-
     def default_config(self) -> dict[str, Any]:
         config = super().default_config()
 

--- a/tests/rest/client/test_auth_issuer.py
+++ b/tests/rest/client/test_auth_issuer.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 from http import HTTPStatus
 
-from relapse.rest.client import auth_issuer
-
 from tests.unittest import HomeserverTestCase, override_config, skip_unless
 from tests.utils import HAS_AUTHLIB
 

--- a/tests/rest/client/test_auth_issuer.py
+++ b/tests/rest/client/test_auth_issuer.py
@@ -22,10 +22,6 @@ ISSUER = "https://account.example.com/"
 
 
 class AuthIssuerTestCase(HomeserverTestCase):
-    servlets = [
-        auth_issuer.register_servlets,
-    ]
-
     def test_returns_404_when_msc3861_disabled(self) -> None:
         # Make an unauthenticated request for the discovery info.
         channel = self.make_request(

--- a/tests/rest/client/test_capabilities.py
+++ b/tests/rest/client/test_capabilities.py
@@ -26,12 +26,6 @@ from tests.unittest import override_config
 
 
 class CapabilitiesTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        capabilities.register_servlets,
-        login.register_servlets,
-    ]
-
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         self.url = "/_matrix/client/r0/capabilities"
         hs = self.setup_test_homeserver()

--- a/tests/rest/client/test_capabilities.py
+++ b/tests/rest/client/test_capabilities.py
@@ -16,8 +16,6 @@ from http import HTTPStatus
 from twisted.internet.testing import MemoryReactor
 
 from relapse.api.room_versions import KNOWN_ROOM_VERSIONS
-from relapse.rest import admin
-from relapse.rest.client import capabilities, login
 from relapse.server import HomeServer
 from relapse.util import Clock
 

--- a/tests/rest/client/test_consent.py
+++ b/tests/rest/client/test_consent.py
@@ -18,9 +18,6 @@ from http import HTTPStatus
 from twisted.internet.testing import MemoryReactor
 
 from relapse.api.urls import ConsentURIBuilder
-from relapse.rest import admin
-from relapse.rest.client import login, room
-from relapse.rest.consent import ConsentServlet
 from relapse.server import HomeServer
 from relapse.util import Clock
 

--- a/tests/rest/client/test_consent.py
+++ b/tests/rest/client/test_consent.py
@@ -28,12 +28,6 @@ from tests import unittest
 
 
 class ConsentResourceTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-        lambda hs, http_server: ConsentServlet(hs).register(http_server),
-    ]
     user_id = True
     hijack_auth = False
 
@@ -50,6 +44,9 @@ class ConsentResourceTestCase(unittest.HomeserverTestCase):
             "version": "1",
             "template_dir": os.path.abspath(temp_consent_path),
         }
+
+        # Load the consent resources.
+        config["listeners"][0]["resources"][0]["names"].append("consent")
 
         with open(os.path.join(temp_consent_path, "en/1.html"), "w") as f:
             f.write("{{version}},{{has_consented}}")

--- a/tests/rest/client/test_devices.py
+++ b/tests/rest/client/test_devices.py
@@ -29,16 +29,6 @@ from tests import unittest
 class DeviceListsTestCase(unittest.HomeserverTestCase):
     """Tests regarding device list changes."""
 
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        register.register_servlets,
-        account.register_servlets,
-        room.register_servlets,
-        sync.register_servlets,
-        devices.register_servlets,
-    ]
-
     def test_receiving_local_device_list_changes(self) -> None:
         """Tests that a local users that share a room receive each other's device list
         changes.
@@ -167,12 +157,6 @@ class DeviceListsTestCase(unittest.HomeserverTestCase):
 
 
 class DevicesTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        sync.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.handler = hs.get_device_handler()
 
@@ -205,14 +189,6 @@ class DevicesTestCase(unittest.HomeserverTestCase):
 
 
 class DehydratedDeviceTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        register.register_servlets,
-        devices.register_servlets,
-        keys.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.registration = hs.get_registration_handler()
         self.message_handler = hs.get_device_message_handler()

--- a/tests/rest/client/test_devices.py
+++ b/tests/rest/client/test_devices.py
@@ -17,8 +17,6 @@ from twisted.internet.defer import ensureDeferred
 from twisted.internet.testing import MemoryReactor
 
 from relapse.api.errors import NotFoundError
-from relapse.rest import admin
-from relapse.rest.client import account, devices, keys, login, register, room, sync
 from relapse.server import HomeServer
 from relapse.types import JsonDict, UserID, create_requester
 from relapse.util import Clock

--- a/tests/rest/client/test_directory.py
+++ b/tests/rest/client/test_directory.py
@@ -28,13 +28,6 @@ from tests.unittest import override_config
 
 
 class DirectoryTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        directory.register_servlets,
-        login.register_servlets,
-        room.register_servlets,
-    ]
-
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         config = self.default_config()
         config["require_membership_for_aliases"] = True

--- a/tests/rest/client/test_directory.py
+++ b/tests/rest/client/test_directory.py
@@ -16,8 +16,6 @@ from http import HTTPStatus
 from twisted.internet.testing import MemoryReactor
 
 from relapse.appservice import ApplicationService
-from relapse.rest import admin
-from relapse.rest.client import directory, login, room
 from relapse.server import HomeServer
 from relapse.types import RoomAlias
 from relapse.util import Clock

--- a/tests/rest/client/test_ephemeral_message.py
+++ b/tests/rest/client/test_ephemeral_message.py
@@ -28,11 +28,6 @@ from tests import unittest
 class EphemeralMessageTestCase(unittest.HomeserverTestCase):
     user_id = "@user:test"
 
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-    ]
-
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         config = self.default_config()
 

--- a/tests/rest/client/test_ephemeral_message.py
+++ b/tests/rest/client/test_ephemeral_message.py
@@ -16,8 +16,6 @@ from http import HTTPStatus
 from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EventContentFields, EventTypes
-from relapse.rest import admin
-from relapse.rest.client import room
 from relapse.server import HomeServer
 from relapse.types import JsonDict
 from relapse.util import Clock

--- a/tests/rest/client/test_events.py
+++ b/tests/rest/client/test_events.py
@@ -19,8 +19,6 @@ from unittest.mock import Mock
 from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EduTypes
-from relapse.rest import admin
-from relapse.rest.client import events, login, room
 from relapse.server import HomeServer
 from relapse.util import Clock
 

--- a/tests/rest/client/test_events.py
+++ b/tests/rest/client/test_events.py
@@ -30,13 +30,6 @@ from tests import unittest
 class EventStreamPermissionsTestCase(unittest.HomeserverTestCase):
     """Tests event streaming (GET /events)."""
 
-    servlets = [
-        events.register_servlets,
-        room.register_servlets,
-        admin.register_servlets,
-        login.register_servlets,
-    ]
-
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         config = self.default_config()
         config["enable_registration_captcha"] = False
@@ -133,13 +126,6 @@ class EventStreamPermissionsTestCase(unittest.HomeserverTestCase):
 
 
 class GetEventsTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        events.register_servlets,
-        room.register_servlets,
-        admin.register_servlets,
-        login.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         # register an account
         self.user_id = self.register_user("sid1", "pass")

--- a/tests/rest/client/test_filter.py
+++ b/tests/rest/client/test_filter.py
@@ -15,7 +15,6 @@
 from twisted.internet.testing import MemoryReactor
 
 from relapse.api.errors import Codes
-from relapse.rest.client import filter
 from relapse.server import HomeServer
 from relapse.types import UserID
 from relapse.util import Clock

--- a/tests/rest/client/test_filter.py
+++ b/tests/rest/client/test_filter.py
@@ -30,7 +30,6 @@ class FilterTestCase(unittest.HomeserverTestCase):
     hijack_auth = True
     EXAMPLE_FILTER = {"room": {"timeline": {"types": ["m.room.message"]}}}
     EXAMPLE_FILTER_JSON = b'{"room": {"timeline": {"types": ["m.room.message"]}}}'
-    servlets = [filter.register_servlets]
 
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.filtering = hs.get_filtering()

--- a/tests/rest/client/test_identity.py
+++ b/tests/rest/client/test_identity.py
@@ -16,8 +16,6 @@ from http import HTTPStatus
 
 from twisted.internet.testing import MemoryReactor
 
-from relapse.rest import admin
-from relapse.rest.client import login, room
 from relapse.server import HomeServer
 from relapse.util import Clock
 

--- a/tests/rest/client/test_identity.py
+++ b/tests/rest/client/test_identity.py
@@ -25,12 +25,6 @@ from tests import unittest
 
 
 class IdentityTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-    ]
-
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         config = self.default_config()
         config["enable_3pid_lookup"] = False

--- a/tests/rest/client/test_keys.py
+++ b/tests/rest/client/test_keys.py
@@ -23,8 +23,6 @@ from signedjson.key import (
 from signedjson.sign import sign_json
 
 from relapse.api.errors import Codes
-from relapse.rest import admin
-from relapse.rest.client import keys, login
 from relapse.types import JsonDict, Requester, create_requester
 
 from tests import unittest

--- a/tests/rest/client/test_keys.py
+++ b/tests/rest/client/test_keys.py
@@ -37,12 +37,6 @@ from tests.utils import HAS_AUTHLIB
 
 
 class KeyQueryTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        keys.register_servlets,
-        admin.register_servlets,
-        login.register_servlets,
-    ]
-
     def test_rejects_device_id_ice_key_outside_of_list(self) -> None:
         self.register_user("alice", "wonderland")
         alice_token = self.login("alice", "wonderland")
@@ -269,11 +263,6 @@ class KeyQueryTestCase(unittest.HomeserverTestCase):
 
 
 class SigningKeyUploadServletTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        keys.register_servlets,
-    ]
-
     OIDC_ADMIN_TOKEN = "_oidc_admin_token"
 
     @unittest.skip_unless(HAS_AUTHLIB, "requires authlib")

--- a/tests/rest/client/test_login.py
+++ b/tests/rest/client/test_login.py
@@ -26,10 +26,7 @@ from relapse.api.constants import ApprovalNoticeMedium, LoginType
 from relapse.api.errors import Codes
 from relapse.appservice import ApplicationService
 from relapse.module_api import ModuleApi
-from relapse.rest import admin
-from relapse.rest.client import devices, login, logout, register
-from relapse.rest.client.account import WhoamiRestServlet
-from relapse.rest.relapse import client as relapse_client
+from relapse.rest.client import login
 from relapse.server import HomeServer
 from relapse.types import JsonDict, create_requester
 from relapse.util import Clock

--- a/tests/rest/client/test_login.py
+++ b/tests/rest/client/test_login.py
@@ -132,15 +132,6 @@ class DenyAllSpamChecker:
 
 
 class LoginRestServletTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        logout.register_servlets,
-        devices.register_servlets,
-        lambda hs, http_server: WhoamiRestServlet(hs).register(http_server),
-        register.register_servlets,
-    ]
-
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         self.hs = self.setup_test_homeserver()
         self.hs.config.registration.enable_registration = True
@@ -585,11 +576,6 @@ class LoginRestServletTestCase(unittest.HomeserverTestCase):
 class MultiSSOTestCase(unittest.HomeserverTestCase):
     """Tests for homeservers with multiple SSO providers enabled"""
 
-    servlets = [
-        login.register_servlets,
-        relapse_client.register_servlets,
-    ]
-
     def default_config(self) -> dict[str, Any]:
         config = super().default_config()
 
@@ -863,10 +849,6 @@ class MultiSSOTestCase(unittest.HomeserverTestCase):
 
 
 class CASTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        login.register_servlets,
-    ]
-
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         self.base_url = "https://matrix.goodserver.com/"
         self.redirect_path = "_relapse/client/login/sso/redirect/confirm"
@@ -1007,11 +989,6 @@ class CASTestCase(unittest.HomeserverTestCase):
 
 @skip_unless(HAS_JWT, "requires authlib")
 class JWTTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-    ]
-
     jwt_secret = "secret"
     jwt_algorithm = "HS256"
     base_config = {
@@ -1199,10 +1176,6 @@ class JWTTestCase(unittest.HomeserverTestCase):
 # signed by the private key.
 @skip_unless(HAS_JWT, "requires authlib")
 class JWTPubKeyTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        login.register_servlets,
-    ]
-
     # This key's pubkey is used as the jwt_secret setting of relapse. Valid
     # tokens are signed by this and validated using the pubkey. It is generated
     # with `openssl genrsa 512` (not a secure way to generate real keys, but
@@ -1288,11 +1261,6 @@ AS_USER = "as_user_alice"
 
 
 class AppserviceLoginRestServletTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        login.register_servlets,
-        register.register_servlets,
-    ]
-
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         self.hs = self.setup_test_homeserver()
 
@@ -1399,8 +1367,6 @@ class AppserviceLoginRestServletTestCase(unittest.HomeserverTestCase):
 @skip_unless(HAS_OIDC, "requires OIDC")
 class UsernamePickerTestCase(HomeserverTestCase):
     """Tests for the username picker flow of SSO login"""
-
-    servlets = [login.register_servlets, relapse_client.register_servlets]
 
     def default_config(self) -> dict[str, Any]:
         config = super().default_config()

--- a/tests/rest/client/test_login_token_request.py
+++ b/tests/rest/client/test_login_token_request.py
@@ -26,13 +26,6 @@ GET_TOKEN_ENDPOINT = "/_matrix/client/v1/login/get_token"
 
 
 class LoginTokenRequestServletTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        login.register_servlets,
-        admin.register_servlets,
-        login_token_request.register_servlets,
-        versions.register_servlets,  # TODO: remove once unstable revision 0 support is removed
-    ]
-
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         self.hs = self.setup_test_homeserver()
         self.hs.config.registration.enable_registration = True

--- a/tests/rest/client/test_login_token_request.py
+++ b/tests/rest/client/test_login_token_request.py
@@ -14,8 +14,6 @@
 
 from twisted.internet.testing import MemoryReactor
 
-from relapse.rest import admin
-from relapse.rest.client import login, login_token_request, versions
 from relapse.server import HomeServer
 from relapse.util import Clock
 

--- a/tests/rest/client/test_mutual_rooms.py
+++ b/tests/rest/client/test_mutual_rooms.py
@@ -15,8 +15,6 @@ from urllib.parse import quote
 
 from twisted.internet.testing import MemoryReactor
 
-from relapse.rest import admin
-from relapse.rest.client import login, mutual_rooms, room
 from relapse.server import HomeServer
 from relapse.util import Clock
 

--- a/tests/rest/client/test_mutual_rooms.py
+++ b/tests/rest/client/test_mutual_rooms.py
@@ -29,13 +29,6 @@ class UserMutualRoomsTest(unittest.HomeserverTestCase):
     Tests the UserMutualRoomsServlet.
     """
 
-    servlets = [
-        login.register_servlets,
-        admin.register_servlets,
-        room.register_servlets,
-        mutual_rooms.register_servlets,
-    ]
-
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         config = self.default_config()
         return self.setup_test_homeserver(config=config)

--- a/tests/rest/client/test_notifications.py
+++ b/tests/rest/client/test_notifications.py
@@ -24,14 +24,6 @@ from tests.unittest import HomeserverTestCase
 
 
 class HTTPPusherTests(HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-        receipts.register_servlets,
-        notifications.register_servlets,
-    ]
-
     def prepare(
         self, reactor: MemoryReactor, clock: Clock, homeserver: HomeServer
     ) -> None:

--- a/tests/rest/client/test_notifications.py
+++ b/tests/rest/client/test_notifications.py
@@ -15,8 +15,6 @@ from unittest.mock import AsyncMock, Mock
 
 from twisted.internet.testing import MemoryReactor
 
-from relapse.rest import admin
-from relapse.rest.client import login, notifications, receipts, room
 from relapse.server import HomeServer
 from relapse.util import Clock
 

--- a/tests/rest/client/test_password_policy.py
+++ b/tests/rest/client/test_password_policy.py
@@ -42,14 +42,6 @@ class PasswordPolicyTestCase(unittest.HomeserverTestCase):
     one it is currently testing (nor any test that comes afterward).
     """
 
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        register.register_servlets,
-        password_policy.register_servlets,
-        account.register_servlets,
-    ]
-
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         self.register_url = "/_matrix/client/r0/register"
         self.policy = {

--- a/tests/rest/client/test_password_policy.py
+++ b/tests/rest/client/test_password_policy.py
@@ -18,8 +18,6 @@ from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import LoginType
 from relapse.api.errors import Codes
-from relapse.rest import admin
-from relapse.rest.client import account, login, password_policy, register
 from relapse.server import HomeServer
 from relapse.util import Clock
 

--- a/tests/rest/client/test_power_levels.py
+++ b/tests/rest/client/test_power_levels.py
@@ -17,8 +17,6 @@ from twisted.internet.testing import MemoryReactor
 
 from relapse.api.errors import Codes
 from relapse.events.utils import CANONICALJSON_MAX_INT, CANONICALJSON_MIN_INT
-from relapse.rest import admin
-from relapse.rest.client import login, room, sync
 from relapse.server import HomeServer
 from relapse.util import Clock
 

--- a/tests/rest/client/test_power_levels.py
+++ b/tests/rest/client/test_power_levels.py
@@ -28,13 +28,6 @@ from tests.unittest import HomeserverTestCase
 class PowerLevelsTestCase(HomeserverTestCase):
     """Tests that power levels are enforced in various situations"""
 
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-        sync.register_servlets,
-    ]
-
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         config = self.default_config()
 

--- a/tests/rest/client/test_presence.py
+++ b/tests/rest/client/test_presence.py
@@ -17,7 +17,6 @@ from unittest.mock import AsyncMock, Mock
 from twisted.internet.testing import MemoryReactor
 
 from relapse.handlers.presence import PresenceHandler
-from relapse.rest.client import presence
 from relapse.server import HomeServer
 from relapse.types import UserID
 from relapse.util import Clock

--- a/tests/rest/client/test_presence.py
+++ b/tests/rest/client/test_presence.py
@@ -31,7 +31,6 @@ class PresenceTestCase(unittest.HomeserverTestCase):
     user_id = "@sid:red"
 
     user = UserID.from_string(user_id)
-    servlets = [presence.register_servlets]
 
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         self.presence_handler = Mock(spec=PresenceHandler)

--- a/tests/rest/client/test_profile.py
+++ b/tests/rest/client/test_profile.py
@@ -21,8 +21,6 @@ from typing import Any
 from twisted.internet.testing import MemoryReactor
 
 from relapse.api.errors import Codes
-from relapse.rest import admin
-from relapse.rest.client import login, profile, room
 from relapse.server import HomeServer
 from relapse.types import UserID
 from relapse.util import Clock

--- a/tests/rest/client/test_profile.py
+++ b/tests/rest/client/test_profile.py
@@ -31,13 +31,6 @@ from tests import unittest
 
 
 class ProfileTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        profile.register_servlets,
-        room.register_servlets,
-    ]
-
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         self.hs = self.setup_test_homeserver()
         return self.hs
@@ -499,13 +492,6 @@ class ProfileTestCase(unittest.HomeserverTestCase):
 
 
 class ProfilesRestrictedTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        profile.register_servlets,
-        room.register_servlets,
-    ]
-
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         config = self.default_config()
         config["require_auth_for_profile_requests"] = True
@@ -578,12 +564,6 @@ class ProfilesRestrictedTestCase(unittest.HomeserverTestCase):
 
 
 class OwnProfileUnrestrictedTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        profile.register_servlets,
-    ]
-
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         config = self.default_config()
         config["require_auth_for_profile_requests"] = True

--- a/tests/rest/client/test_push_rule_attrs.py
+++ b/tests/rest/client/test_push_rule_attrs.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from relapse.api.errors import Codes
-from relapse.rest import admin
-from relapse.rest.client import login, push_rule, room
 
 from tests.unittest import HomeserverTestCase
 

--- a/tests/rest/client/test_push_rule_attrs.py
+++ b/tests/rest/client/test_push_rule_attrs.py
@@ -19,12 +19,6 @@ from tests.unittest import HomeserverTestCase
 
 
 class PushRuleAttributesTestCase(HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-        push_rule.register_servlets,
-    ]
     hijack_auth = False
 
     def test_enabled_on_creation(self) -> None:

--- a/tests/rest/client/test_read_marker.py
+++ b/tests/rest/client/test_read_marker.py
@@ -26,15 +26,6 @@ ONE_DAY_MS = ONE_HOUR_MS * 24
 
 
 class ReadMarkerTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        login.register_servlets,
-        register.register_servlets,
-        read_marker.register_servlets,
-        room.register_servlets,
-        admin.register_servlets,
-        admin.register_servlets,
-    ]
-
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         config = self.default_config()
 

--- a/tests/rest/client/test_read_marker.py
+++ b/tests/rest/client/test_read_marker.py
@@ -14,8 +14,6 @@
 from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EventTypes
-from relapse.rest import admin
-from relapse.rest.client import login, read_marker, register, room
 from relapse.server import HomeServer
 from relapse.util import Clock
 

--- a/tests/rest/client/test_receipts.py
+++ b/tests/rest/client/test_receipts.py
@@ -26,14 +26,6 @@ from tests import unittest
 
 
 class ReceiptsTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        login.register_servlets,
-        receipts.register_servlets,
-        admin.register_servlets,
-        room.register_servlets,
-        sync.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.url = "/_matrix/client/r0/sync?since=%s"
         self.next_batch = "s0"

--- a/tests/rest/client/test_receipts.py
+++ b/tests/rest/client/test_receipts.py
@@ -16,8 +16,6 @@ from http import HTTPStatus
 from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EduTypes, EventTypes, HistoryVisibility, ReceiptTypes
-from relapse.rest import admin
-from relapse.rest.client import login, receipts, room, sync
 from relapse.server import HomeServer
 from relapse.types import JsonDict
 from relapse.util import Clock

--- a/tests/rest/client/test_redactions.py
+++ b/tests/rest/client/test_redactions.py
@@ -18,8 +18,6 @@ from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EventTypes, RelationTypes
 from relapse.api.room_versions import RoomVersion, RoomVersions
-from relapse.rest import admin
-from relapse.rest.client import login, room, sync
 from relapse.server import HomeServer
 from relapse.storage._base import db_to_json
 from relapse.storage.database import LoggingTransaction

--- a/tests/rest/client/test_redactions.py
+++ b/tests/rest/client/test_redactions.py
@@ -32,13 +32,6 @@ from tests.unittest import HomeserverTestCase, override_config
 class RedactionsTestCase(HomeserverTestCase):
     """Tests that various redaction events are handled correctly"""
 
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-        sync.register_servlets,
-    ]
-
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         config = self.default_config()
 

--- a/tests/rest/client/test_register.py
+++ b/tests/rest/client/test_register.py
@@ -26,8 +26,6 @@ from relapse.api.constants import (
 )
 from relapse.api.errors import Codes
 from relapse.appservice import ApplicationService
-from relapse.rest import admin
-from relapse.rest.client import account, account_validity, login, logout, register, sync
 from relapse.server import HomeServer
 from relapse.storage._base import db_to_json
 from relapse.types import JsonDict

--- a/tests/rest/client/test_register.py
+++ b/tests/rest/client/test_register.py
@@ -38,11 +38,6 @@ from tests.unittest import override_config
 
 
 class RegisterRestServletTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        login.register_servlets,
-        register.register_servlets,
-        admin.register_servlets,
-    ]
     url = "/_matrix/client/r0/register"
 
     def default_config(self) -> dict[str, Any]:
@@ -796,15 +791,6 @@ class RegisterRestServletTestCase(unittest.HomeserverTestCase):
 
 
 class AccountValidityTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        register.register_servlets,
-        admin.register_servlets,
-        login.register_servlets,
-        sync.register_servlets,
-        logout.register_servlets,
-        account_validity.register_servlets,
-    ]
-
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         config = self.default_config()
         # Test for account expiring after a week.
@@ -915,15 +901,6 @@ class AccountValidityTestCase(unittest.HomeserverTestCase):
 
 
 class AccountValidityRenewalByEmailTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        register.register_servlets,
-        admin.register_servlets,
-        login.register_servlets,
-        sync.register_servlets,
-        account_validity.register_servlets,
-        account.register_servlets,
-    ]
-
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         config = self.default_config()
 
@@ -1136,8 +1113,6 @@ class AccountValidityRenewalByEmailTestCase(unittest.HomeserverTestCase):
 
 
 class AccountValidityBackgroundJobTestCase(unittest.HomeserverTestCase):
-    servlets = [admin.register_servlets]
-
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         self.validity_period = 10
         self.max_delta = self.validity_period * 10.0 / 100.0
@@ -1184,7 +1159,6 @@ class AccountValidityBackgroundJobTestCase(unittest.HomeserverTestCase):
 
 
 class RegistrationTokenValidityRestServletTestCase(unittest.HomeserverTestCase):
-    servlets = [register.register_servlets]
     url = "/_matrix/client/v1/register/m.login.registration_token/validity"
 
     def default_config(self) -> dict[str, Any]:

--- a/tests/rest/client/test_relations.py
+++ b/tests/rest/client/test_relations.py
@@ -33,14 +33,6 @@ from tests.test_utils.event_injection import inject_event
 
 
 class BaseRelationsTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        relations.register_servlets,
-        room.register_servlets,
-        sync.register_servlets,
-        login.register_servlets,
-        register.register_servlets,
-        admin.register_servlets,
-    ]
     hijack_auth = False
 
     def default_config(self) -> dict[str, Any]:

--- a/tests/rest/client/test_relations.py
+++ b/tests/rest/client/test_relations.py
@@ -21,8 +21,6 @@ from unittest.mock import AsyncMock, patch
 from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import AccountDataTypes, EventTypes, RelationTypes
-from relapse.rest import admin
-from relapse.rest.client import login, register, relations, room, sync
 from relapse.server import HomeServer
 from relapse.types import JsonDict
 from relapse.util import Clock

--- a/tests/rest/client/test_report_event.py
+++ b/tests/rest/client/test_report_event.py
@@ -24,13 +24,6 @@ from tests import unittest
 
 
 class ReportEventTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        room.register_servlets,
-        report_event.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.admin_user = self.register_user("admin", "pass", admin=True)
         self.admin_user_tok = self.login("admin", "pass")

--- a/tests/rest/client/test_report_event.py
+++ b/tests/rest/client/test_report_event.py
@@ -14,8 +14,6 @@
 
 from twisted.internet.testing import MemoryReactor
 
-from relapse.rest import admin
-from relapse.rest.client import login, report_event, room
 from relapse.server import HomeServer
 from relapse.types import JsonDict
 from relapse.util import Clock

--- a/tests/rest/client/test_retention.py
+++ b/tests/rest/client/test_retention.py
@@ -32,12 +32,6 @@ one_day_ms = one_hour_ms * 24
 
 
 class RetentionTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        room.register_servlets,
-    ]
-
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         config = self.default_config()
 
@@ -249,12 +243,6 @@ class RetentionTestCase(unittest.HomeserverTestCase):
 
 
 class RetentionNoDefaultPolicyTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        room.register_servlets,
-    ]
-
     def default_config(self) -> dict[str, Any]:
         config = super().default_config()
 

--- a/tests/rest/client/test_retention.py
+++ b/tests/rest/client/test_retention.py
@@ -17,8 +17,6 @@ from unittest.mock import Mock
 from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EventTypes
-from relapse.rest import admin
-from relapse.rest.client import login, room
 from relapse.server import HomeServer
 from relapse.types import JsonDict, create_requester
 from relapse.util import Clock

--- a/tests/rest/client/test_rooms.py
+++ b/tests/rest/client/test_rooms.py
@@ -61,8 +61,6 @@ from tests.unittest import override_config
 class RoomBase(unittest.HomeserverTestCase):
     rmcreator_id: str | None = None
 
-    servlets = [room.register_servlets, room.register_deprecated_servlets]
-
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         self.hs = self.setup_test_homeserver(
             "red",
@@ -525,8 +523,6 @@ class RoomStateTestCase(RoomBase):
 
 class RoomsMemberListTestCase(RoomBase):
     """Tests /rooms/$room_id/members/list REST events."""
-
-    servlets = RoomBase.servlets + [sync.register_servlets]
 
     user_id = "@sid1:red"
 
@@ -1111,12 +1107,6 @@ class RoomMemberStateTestCase(RoomBase):
 class RoomInviteRatelimitTestCase(RoomBase):
     user_id = "@sid1:red"
 
-    servlets = [
-        admin.register_servlets,
-        profile.register_servlets,
-        room.register_servlets,
-    ]
-
     @unittest.override_config(
         {"rc_invites": {"per_room": {"per_second": 0.5, "burst_count": 3}}}
     )
@@ -1144,12 +1134,6 @@ class RoomInviteRatelimitTestCase(RoomBase):
 
 
 class RoomJoinTestCase(RoomBase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        room.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.user1 = self.register_user("thomas", "hackme")
         self.tok1 = self.login("thomas", "hackme")
@@ -1313,12 +1297,6 @@ class RoomJoinTestCase(RoomBase):
 
 
 class RoomAppserviceTsParamTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        room.register_servlets,
-        admin.register_servlets,
-        register.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.appservice_user, _ = self.register_appservice_user(
             "as_user_potato", self.appservice.token
@@ -1428,12 +1406,6 @@ class RoomAppserviceTsParamTestCase(unittest.HomeserverTestCase):
 
 class RoomJoinRatelimitTestCase(RoomBase):
     user_id = "@sid1:red"
-
-    servlets = [
-        admin.register_servlets,
-        profile.register_servlets,
-        room.register_servlets,
-    ]
 
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         super().prepare(reactor, clock, hs)
@@ -1722,12 +1694,6 @@ class RoomPowerLevelOverridesTestCase(RoomBase):
     """Tests that the power levels can be overridden with server config."""
 
     user_id = "@sid1:red"
-
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-    ]
 
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.admin_user_id = self.register_user("admin", "pass")
@@ -2155,11 +2121,6 @@ class RoomMessageListTestCase(RoomBase):
 
 
 class RoomSearchTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-    ]
     user_id = True
     hijack_auth = False
 
@@ -2256,12 +2217,6 @@ class RoomSearchTestCase(unittest.HomeserverTestCase):
 
 
 class PublicRoomsRestrictedTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-    ]
-
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         self.url = "/_matrix/client/r0/publicRooms"
 
@@ -2284,12 +2239,6 @@ class PublicRoomsRestrictedTestCase(unittest.HomeserverTestCase):
 
 
 class PublicRoomsRoomTypeFilterTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-    ]
-
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         config = self.default_config()
         config["allow_public_rooms_without_auth"] = True
@@ -2390,12 +2339,6 @@ class PublicRoomsTestRemoteSearchFallbackTestCase(unittest.HomeserverTestCase):
     doesn't support search.
     """
 
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-    ]
-
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         return self.setup_test_homeserver(federation_client=AsyncMock())
 
@@ -2471,13 +2414,6 @@ class PublicRoomsTestRemoteSearchFallbackTestCase(unittest.HomeserverTestCase):
 
 
 class PerRoomProfilesForbiddenTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-        profile.register_servlets,
-    ]
-
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         config = self.default_config()
         config["allow_per_room_profiles"] = False
@@ -2528,12 +2464,6 @@ class RoomMembershipReasonTestCase(unittest.HomeserverTestCase):
     """Tests that clients can add a "reason" field to membership events and
     that they get correctly added to the generated events and propagated.
     """
-
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-    ]
 
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.creator = self.register_user("creator", "test")
@@ -2655,13 +2585,6 @@ class RoomMembershipReasonTestCase(unittest.HomeserverTestCase):
 
 
 class LabelsTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-        profile.register_servlets,
-    ]
-
     # Filter that should only catch messages with the label "#fun".
     FILTER_LABELS = {
         "types": [EventTypes.Message],
@@ -3025,13 +2948,6 @@ class RelationsTestCase(PaginationTestCase):
 
 
 class ContextTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-        account.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.user_id = self.register_user("user", "password")
         self.tok = self.login("user", "password")
@@ -3150,13 +3066,6 @@ class ContextTestCase(unittest.HomeserverTestCase):
 
 
 class RoomAliasListTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        directory.register_servlets,
-        login.register_servlets,
-        room.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.room_owner = self.register_user("room_owner", "test")
         self.room_owner_tok = self.login("room_owner", "test")
@@ -3240,13 +3149,6 @@ class RoomAliasListTestCase(unittest.HomeserverTestCase):
 
 
 class RoomCanonicalAliasTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        directory.register_servlets,
-        login.register_servlets,
-        room.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.room_owner = self.register_user("room_owner", "test")
         self.room_owner_tok = self.login("room_owner", "test")
@@ -3398,12 +3300,6 @@ class RoomCanonicalAliasTestCase(unittest.HomeserverTestCase):
 
 
 class ThreepidInviteTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        room.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.user_id = self.register_user("thomas", "hackme")
         self.tok = self.login("thomas", "hackme")
@@ -3580,12 +3476,6 @@ class ThreepidInviteTestCase(unittest.HomeserverTestCase):
 
 
 class TimestampLookupTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self._storage_controllers = self.hs.get_storage_controllers()
 

--- a/tests/rest/client/test_rooms.py
+++ b/tests/rest/client/test_rooms.py
@@ -41,8 +41,6 @@ from relapse.api.errors import Codes, HttpResponseException
 from relapse.appservice import ApplicationService
 from relapse.events import EventBase
 from relapse.events.snapshot import EventContext
-from relapse.rest import admin
-from relapse.rest.client import account, directory, login, profile, register, room, sync
 from relapse.server import HomeServer
 from relapse.types import JsonDict, RoomAlias, UserID, create_requester
 from relapse.util import Clock

--- a/tests/rest/client/test_sendtodevice.py
+++ b/tests/rest/client/test_sendtodevice.py
@@ -20,13 +20,6 @@ from tests.unittest import HomeserverTestCase, override_config
 
 
 class SendToDeviceTestCase(HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        sendtodevice.register_servlets,
-        sync.register_servlets,
-    ]
-
     def test_user_to_user(self) -> None:
         """A to-device message from one user to another should get delivered"""
 

--- a/tests/rest/client/test_sendtodevice.py
+++ b/tests/rest/client/test_sendtodevice.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 from relapse.api.constants import EduTypes
-from relapse.rest import admin
-from relapse.rest.client import login, sendtodevice, sync
 
 from tests.unittest import HomeserverTestCase, override_config
 

--- a/tests/rest/client/test_shadow_banned.py
+++ b/tests/rest/client/test_shadow_banned.py
@@ -51,14 +51,6 @@ class _ShadowBannedBase(unittest.HomeserverTestCase):
 # To avoid the tests timing out don't add a delay to "annoy the requester".
 @patch("random.randint", new=lambda a, b: 0)
 class RoomTestCase(_ShadowBannedBase):
-    servlets = [
-        admin.register_servlets,
-        directory.register_servlets,
-        login.register_servlets,
-        room.register_servlets,
-        room_upgrade_rest_servlet.register_servlets,
-    ]
-
     def test_invite(self) -> None:
         """Invites from shadow-banned users don't actually get sent."""
 
@@ -242,13 +234,6 @@ class RoomTestCase(_ShadowBannedBase):
 # To avoid the tests timing out don't add a delay to "annoy the requester".
 @patch("random.randint", new=lambda a, b: 0)
 class ProfileTestCase(_ShadowBannedBase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        profile.register_servlets,
-        room.register_servlets,
-    ]
-
     def test_displayname(self) -> None:
         """Profile changes should succeed, but don't end up in a room."""
         original_display_name = "banned"

--- a/tests/rest/client/test_shadow_banned.py
+++ b/tests/rest/client/test_shadow_banned.py
@@ -17,14 +17,6 @@ from unittest.mock import Mock, patch
 from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EduTypes, EventTypes
-from relapse.rest import admin
-from relapse.rest.client import (
-    directory,
-    login,
-    profile,
-    room,
-    room_upgrade_rest_servlet,
-)
 from relapse.server import HomeServer
 from relapse.types import UserID, create_requester
 from relapse.util import Clock

--- a/tests/rest/client/test_sync.py
+++ b/tests/rest/client/test_sync.py
@@ -32,12 +32,6 @@ from tests.server import TimedOutException
 
 class FilterTestCase(unittest.HomeserverTestCase):
     user_id = "@apple:test"
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-        sync.register_servlets,
-    ]
 
     def test_sync_argless(self) -> None:
         channel = self.make_request("GET", "/_matrix/client/r0/sync")
@@ -47,13 +41,6 @@ class FilterTestCase(unittest.HomeserverTestCase):
 
 
 class SyncFilterTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-        sync.register_servlets,
-    ]
-
     def test_sync_filter_labels(self) -> None:
         """Test that we can filter by a label."""
         sync_filter = json.dumps(
@@ -180,12 +167,6 @@ class SyncFilterTestCase(unittest.HomeserverTestCase):
 
 
 class SyncTypingTests(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-        sync.register_servlets,
-    ]
     user_id = True
     hijack_auth = False
 
@@ -285,14 +266,6 @@ class SyncTypingTests(unittest.HomeserverTestCase):
 
 
 class SyncKnockTestCase(KnockingStrippedStateEventHelperMixin):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        room.register_servlets,
-        sync.register_servlets,
-        knock.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.store = hs.get_datastores().main
         self.url = "/_matrix/client/r0/sync?since=%s"
@@ -369,12 +342,6 @@ class SyncKnockTestCase(KnockingStrippedStateEventHelperMixin):
 
 
 class SyncCacheTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        sync.register_servlets,
-    ]
-
     def test_noop_sync_does_not_tightloop(self) -> None:
         """If the sync times out, we shouldn't cache the result
 
@@ -421,13 +388,6 @@ class SyncCacheTestCase(unittest.HomeserverTestCase):
 
 
 class DeviceListSyncTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        sync.register_servlets,
-        devices.register_servlets,
-    ]
-
     def test_user_with_no_rooms_receives_self_device_list_updates(self) -> None:
         """Tests that a user with no rooms still receives their own device list updates"""
         device_id = "TESTDEVICE"
@@ -478,13 +438,6 @@ class DeviceListSyncTestCase(unittest.HomeserverTestCase):
 
 
 class ExcludeRoomTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        sync.register_servlets,
-        room.register_servlets,
-    ]
-
     def prepare(
         self, reactor: MemoryReactor, clock: Clock, homeserver: HomeServer
     ) -> None:

--- a/tests/rest/client/test_sync.py
+++ b/tests/rest/client/test_sync.py
@@ -17,8 +17,6 @@ import json
 from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EventContentFields, EventTypes
-from relapse.rest import admin
-from relapse.rest.client import devices, knock, login, room, sync
 from relapse.server import HomeServer
 from relapse.types import JsonDict
 from relapse.util import Clock

--- a/tests/rest/client/test_third_party_rules.py
+++ b/tests/rest/client/test_third_party_rules.py
@@ -20,8 +20,6 @@ from relapse.api.constants import EventTypes, LoginType, Membership
 from relapse.api.errors import RelapseError
 from relapse.api.room_versions import RoomVersion
 from relapse.events import EventBase
-from relapse.rest import admin
-from relapse.rest.client import account, login, profile, room
 from relapse.server import HomeServer
 from relapse.types import JsonDict, Requester, StateMap
 from relapse.util import Clock

--- a/tests/rest/client/test_third_party_rules.py
+++ b/tests/rest/client/test_third_party_rules.py
@@ -34,14 +34,6 @@ if TYPE_CHECKING:
 
 
 class ThirdPartyRulesTestCase(FederatingHomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        room.register_servlets,
-        profile.register_servlets,
-        account.register_servlets,
-    ] + FederatingHomeserverTestCase.servlets
-
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         hs = self.setup_test_homeserver()
 

--- a/tests/rest/client/test_typing.py
+++ b/tests/rest/client/test_typing.py
@@ -18,7 +18,6 @@
 from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EduTypes
-from relapse.rest.client import room
 from relapse.server import HomeServer
 from relapse.types import UserID
 from relapse.util import Clock

--- a/tests/rest/client/test_typing.py
+++ b/tests/rest/client/test_typing.py
@@ -32,7 +32,6 @@ class RoomTypingTestCase(unittest.HomeserverTestCase):
     user_id = "@sid:red"
 
     user = UserID.from_string(user_id)
-    servlets = [room.register_servlets]
 
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         hs = self.setup_test_homeserver("red")

--- a/tests/rest/client/test_upgrade_room.py
+++ b/tests/rest/client/test_upgrade_room.py
@@ -27,13 +27,6 @@ from tests.server import FakeChannel
 
 
 class UpgradeRoomTest(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        room.register_servlets,
-        room_upgrade_rest_servlet.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.store = hs.get_datastores().main
 

--- a/tests/rest/client/test_upgrade_room.py
+++ b/tests/rest/client/test_upgrade_room.py
@@ -17,8 +17,6 @@ from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EventContentFields, EventTypes, RoomTypes
 from relapse.config.server import DEFAULT_ROOM_VERSION
-from relapse.rest import admin
-from relapse.rest.client import login, room, room_upgrade_rest_servlet
 from relapse.server import HomeServer
 from relapse.util import Clock
 

--- a/tests/rest/client/test_whois.py
+++ b/tests/rest/client/test_whois.py
@@ -16,11 +16,6 @@
 from twisted.internet.testing import MemoryReactor
 
 from relapse.api.errors import Codes
-from relapse.rest import admin
-from relapse.rest.client import (
-    login,
-    whois,
-)
 from relapse.server import HomeServer
 from relapse.util import Clock
 

--- a/tests/rest/client/test_whois.py
+++ b/tests/rest/client/test_whois.py
@@ -28,12 +28,6 @@ from tests import unittest
 
 
 class WhoisRestTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        whois.register_servlets,
-        login.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.admin_user = self.register_user("admin", "pass", admin=True)
         self.admin_user_tok = self.login("admin", "pass")

--- a/tests/rest/federation/test__base.py
+++ b/tests/rest/federation/test__base.py
@@ -61,15 +61,6 @@ class BaseFederationServletCancellationTests(FederatingHomeserverTestCase):
 
     path = f"{CancellableFederationServlet.PREFIX}{CancellableFederationServlet.PATH}"
 
-    servlets = [
-        lambda hs, http_server: CancellableFederationServlet(
-            hs=hs,
-            authenticator=Authenticator(hs),
-            ratelimiter=hs.get_federation_ratelimiter(),
-            server_name=hs.hostname,
-        ).register(http_server)
-    ] + FederatingHomeserverTestCase.servlets
-
     def test_cancellable_disconnect(self) -> None:
         """Test that handlers with the `@cancellable` flag can be cancelled."""
         channel = self.make_signed_federation_request(

--- a/tests/rest/federation/test_knocking.py
+++ b/tests/rest/federation/test_knocking.py
@@ -195,12 +195,6 @@ class KnockingStrippedStateEventHelperMixin(HomeserverTestCase):
 class FederationKnockingTestCase(
     FederatingHomeserverTestCase, KnockingStrippedStateEventHelperMixin
 ):
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-    ] + FederatingHomeserverTestCase.servlets
-
     def prepare(
         self, reactor: MemoryReactor, clock: Clock, homeserver: HomeServer
     ) -> None:

--- a/tests/rest/federation/test_knocking.py
+++ b/tests/rest/federation/test_knocking.py
@@ -20,8 +20,6 @@ from relapse.api.constants import EventTypes, JoinRules, Membership
 from relapse.api.room_versions import RoomVersion, RoomVersions
 from relapse.events import EventBase, builder
 from relapse.events.snapshot import EventContext
-from relapse.rest import admin
-from relapse.rest.client import login, room
 from relapse.server import HomeServer
 from relapse.types import RoomAlias
 from relapse.util import Clock

--- a/tests/rest/key/test_remote_key_resource.py
+++ b/tests/rest/key/test_remote_key_resource.py
@@ -37,8 +37,6 @@ from tests.utils import default_config
 
 
 class BaseRemoteKeyResourceTestCase(unittest.HomeserverTestCase):
-    servlets = [key.register_servlets]
-
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         self.http_client = Mock()
         return self.setup_test_homeserver(federation_http_client=self.http_client)

--- a/tests/rest/key/test_remote_key_resource.py
+++ b/tests/rest/key/test_remote_key_resource.py
@@ -24,7 +24,6 @@ from twisted.internet.testing import MemoryReactor
 
 from relapse.crypto.keyring import PerspectivesKeyFetcher
 from relapse.http.site import RelapseRequest
-from relapse.rest import key
 from relapse.server import HomeServer
 from relapse.storage.keys import FetchKeyResult
 from relapse.types import JsonDict

--- a/tests/rest/media/test_domain_blocking.py
+++ b/tests/rest/media/test_domain_blocking.py
@@ -15,7 +15,6 @@
 from twisted.internet.testing import MemoryReactor
 
 from relapse.media._base import FileInfo
-from relapse.rest import media
 from relapse.server import HomeServer
 from relapse.util import Clock
 

--- a/tests/rest/media/test_domain_blocking.py
+++ b/tests/rest/media/test_domain_blocking.py
@@ -25,8 +25,6 @@ from tests.unittest import override_config
 
 
 class MediaDomainBlockingTests(unittest.HomeserverTestCase):
-    servlets = [media.register_servlets]
-
     remote_media_id = "doesnotmatter"
     remote_server_name = "evil.com"
 

--- a/tests/rest/media/test_url_preview.py
+++ b/tests/rest/media/test_url_preview.py
@@ -50,7 +50,6 @@ class URLPreviewTests(unittest.HomeserverTestCase):
 
     hijack_auth = True
     user_id = "@test:user"
-    servlets = [media.register_servlets]
 
     end_content = (
         b"<html><head>"

--- a/tests/rest/media/test_url_preview.py
+++ b/tests/rest/media/test_url_preview.py
@@ -28,7 +28,6 @@ from twisted.internet.testing import AccumulatingProtocol, MemoryReactor
 
 from relapse.config.oembed import OEmbedEndpointConfig
 from relapse.media.url_previewer import IMAGE_CACHE_EXPIRY_MS
-from relapse.rest import media
 from relapse.server import HomeServer
 from relapse.types import JsonDict
 from relapse.util import Clock

--- a/tests/rest/test_health.py
+++ b/tests/rest/test_health.py
@@ -17,8 +17,6 @@ from tests import unittest
 
 
 class HealthCheckTests(unittest.HomeserverTestCase):
-    servlets = [lambda _, http_server: HealthServlet().register(http_server)]
-
     def test_health(self) -> None:
         channel = self.make_request("GET", "/health")
 

--- a/tests/rest/test_health.py
+++ b/tests/rest/test_health.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from relapse.rest.health import HealthServlet
 
 from tests import unittest
 

--- a/tests/rest/test_well_known.py
+++ b/tests/rest/test_well_known.py
@@ -19,8 +19,6 @@ from tests.utils import HAS_AUTHLIB
 
 
 class WellKnownTests(unittest.HomeserverTestCase):
-    servlets = [well_known.register_servlets]
-
     @unittest.override_config(
         {
             "public_baseurl": "https://tesths",

--- a/tests/rest/test_well_known.py
+++ b/tests/rest/test_well_known.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from relapse.rest import well_known
 
 from tests import unittest
 from tests.utils import HAS_AUTHLIB

--- a/tests/server_notices/test_consent.py
+++ b/tests/server_notices/test_consent.py
@@ -25,13 +25,6 @@ from tests import unittest
 
 
 class ConsentNoticesTests(unittest.HomeserverTestCase):
-    servlets = [
-        sync.register_servlets,
-        admin.register_servlets,
-        login.register_servlets,
-        room.register_servlets,
-    ]
-
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         tmpdir = self.mktemp()
         os.mkdir(tmpdir)

--- a/tests/server_notices/test_consent.py
+++ b/tests/server_notices/test_consent.py
@@ -16,8 +16,6 @@ import os
 
 from twisted.internet.testing import MemoryReactor
 
-from relapse.rest import admin
-from relapse.rest.client import login, room, sync
 from relapse.server import HomeServer
 from relapse.util import Clock
 

--- a/tests/server_notices/test_resource_limits_server_notices.py
+++ b/tests/server_notices/test_resource_limits_server_notices.py
@@ -17,8 +17,6 @@ from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EventTypes, LimitBlockingTypes, ServerNoticeMsgType
 from relapse.api.errors import ResourceLimitError
-from relapse.rest import admin
-from relapse.rest.client import login, room, sync
 from relapse.server import HomeServer
 from relapse.server_notices.resource_limits_server_notices import (
     ResourceLimitsServerNotices,

--- a/tests/server_notices/test_resource_limits_server_notices.py
+++ b/tests/server_notices/test_resource_limits_server_notices.py
@@ -240,13 +240,6 @@ class TestResourceLimitsServerNotices(unittest.HomeserverTestCase):
 
 
 class TestResourceLimitsServerNoticesWithRealRooms(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        room.register_servlets,
-        sync.register_servlets,
-    ]
-
     def default_config(self) -> JsonDict:
         c = super().default_config()
         c["server_notices"] = {

--- a/tests/storage/databases/main/test_deviceinbox.py
+++ b/tests/storage/databases/main/test_deviceinbox.py
@@ -23,11 +23,6 @@ from tests.unittest import HomeserverTestCase
 
 
 class DeviceInboxBackgroundUpdateStoreTestCase(HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        devices.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.store = hs.get_datastores().main
         self.user_id = self.register_user("foo", "pass")

--- a/tests/storage/databases/main/test_deviceinbox.py
+++ b/tests/storage/databases/main/test_deviceinbox.py
@@ -14,8 +14,6 @@
 
 from twisted.internet.testing import MemoryReactor
 
-from relapse.rest import admin
-from relapse.rest.client import devices
 from relapse.server import HomeServer
 from relapse.util import Clock
 

--- a/tests/storage/databases/main/test_events_worker.py
+++ b/tests/storage/databases/main/test_events_worker.py
@@ -39,12 +39,6 @@ from tests.test_utils.event_injection import create_event, inject_event
 
 
 class HaveSeenEventsTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.hs = hs
         self.store: EventsWorkerStore = hs.get_datastores().main
@@ -218,12 +212,6 @@ class HaveSeenEventsTestCase(unittest.HomeserverTestCase):
 
 class EventCacheTestCase(unittest.HomeserverTestCase):
     """Test that the various layers of event cache works."""
-
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-    ]
 
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.store: EventsWorkerStore = hs.get_datastores().main
@@ -420,12 +408,6 @@ class DatabaseOutageTestCase(unittest.HomeserverTestCase):
 
 class GetEventCancellationTestCase(unittest.HomeserverTestCase):
     """Test cancellation of `get_event` calls."""
-
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-    ]
 
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.store: EventsWorkerStore = hs.get_datastores().main

--- a/tests/storage/databases/main/test_events_worker.py
+++ b/tests/storage/databases/main/test_events_worker.py
@@ -23,8 +23,6 @@ from twisted.internet.testing import MemoryReactor
 from relapse.api.room_versions import EventFormatVersions, RoomVersions
 from relapse.events import make_event_from_dict
 from relapse.logging.context import LoggingContext
-from relapse.rest import admin
-from relapse.rest.client import login, room
 from relapse.server import HomeServer
 from relapse.storage.databases.main.events_worker import (
     EVENT_QUEUE_THREADS,

--- a/tests/storage/databases/main/test_receipts.py
+++ b/tests/storage/databases/main/test_receipts.py
@@ -17,8 +17,6 @@ from typing import Any
 
 from twisted.internet.testing import MemoryReactor
 
-from relapse.rest import admin
-from relapse.rest.client import login, room
 from relapse.server import HomeServer
 from relapse.storage.database import LoggingTransaction
 from relapse.util import Clock

--- a/tests/storage/databases/main/test_receipts.py
+++ b/tests/storage/databases/main/test_receipts.py
@@ -27,12 +27,6 @@ from tests.unittest import HomeserverTestCase
 
 
 class ReceiptsBackgroundUpdateStoreTestCase(HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.store = hs.get_datastores().main
         self.user_id = self.register_user("foo", "pass")

--- a/tests/storage/databases/main/test_room.py
+++ b/tests/storage/databases/main/test_room.py
@@ -17,8 +17,6 @@ import json
 from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import RoomTypes
-from relapse.rest import admin
-from relapse.rest.client import login, room
 from relapse.server import HomeServer
 from relapse.storage.databases.main.room import _BackgroundUpdates
 from relapse.util import Clock

--- a/tests/storage/databases/main/test_room.py
+++ b/tests/storage/databases/main/test_room.py
@@ -27,12 +27,6 @@ from tests.unittest import HomeserverTestCase
 
 
 class RoomBackgroundUpdateStoreTestCase(HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.store = hs.get_datastores().main
         self.user_id = self.register_user("foo", "pass")

--- a/tests/storage/test_cleanup_extrems.py
+++ b/tests/storage/test_cleanup_extrems.py
@@ -254,11 +254,6 @@ class CleanupExtremBackgroundUpdateStoreTestCase(HomeserverTestCase):
 class CleanupExtremDummyEventsTestCase(HomeserverTestCase):
     CONSENT_VERSION = "1"
     EXTREMITIES_COUNT = 50
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        room.register_servlets,
-    ]
 
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         config = self.default_config()

--- a/tests/storage/test_cleanup_extrems.py
+++ b/tests/storage/test_cleanup_extrems.py
@@ -18,8 +18,6 @@ from unittest.mock import Mock, patch
 from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EventTypes
-from relapse.rest import admin
-from relapse.rest.client import login, room
 from relapse.server import HomeServer
 from relapse.storage import prepare_database
 from relapse.storage.types import Cursor

--- a/tests/storage/test_client_ips.py
+++ b/tests/storage/test_client_ips.py
@@ -21,8 +21,6 @@ from parameterized import parameterized
 from twisted.internet.testing import MemoryReactor
 
 from relapse.http.site import XForwardedForRequest
-from relapse.rest import admin
-from relapse.rest.client import login
 from relapse.server import HomeServer
 from relapse.storage.databases.main.client_ips import (
     LAST_SEEN_GRANULARITY,

--- a/tests/storage/test_client_ips.py
+++ b/tests/storage/test_client_ips.py
@@ -710,11 +710,6 @@ class ClientIpStoreTestCase(unittest.HomeserverTestCase):
 
 
 class ClientIpAuthTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.store = self.hs.get_datastores().main
         self.user_id = self.register_user("bob", "abc123", True)

--- a/tests/storage/test_event_chain.py
+++ b/tests/storage/test_event_chain.py
@@ -21,8 +21,6 @@ from relapse.api.constants import EventTypes
 from relapse.api.room_versions import RoomVersions
 from relapse.events import EventBase
 from relapse.events.snapshot import EventContext
-from relapse.rest import admin
-from relapse.rest.client import login, room
 from relapse.server import HomeServer
 from relapse.storage.database import LoggingTransaction
 from relapse.storage.databases.main.events import _LinkMap

--- a/tests/storage/test_event_chain.py
+++ b/tests/storage/test_event_chain.py
@@ -506,12 +506,6 @@ class LinkMapTestCase(unittest.TestCase):
 
 
 class EventChainBackgroundUpdateTestCase(HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.store = hs.get_datastores().main
         self.user_id = self.register_user("foo", "pass")

--- a/tests/storage/test_event_federation.py
+++ b/tests/storage/test_event_federation.py
@@ -28,8 +28,6 @@ from relapse.api.room_versions import (
     RoomVersion,
 )
 from relapse.events import EventBase, _EventInternalMetadata
-from relapse.rest import admin
-from relapse.rest.client import login, room
 from relapse.server import HomeServer
 from relapse.storage.database import LoggingTransaction
 from relapse.storage.types import Cursor

--- a/tests/storage/test_event_federation.py
+++ b/tests/storage/test_event_federation.py
@@ -179,12 +179,6 @@ class _BackfillSetupInfo:
 
 
 class EventFederationWorkerStoreTestCase(tests.unittest.HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.store = hs.get_datastores().main
         persist_events = hs.get_datastores().persist_events

--- a/tests/storage/test_event_push_actions.py
+++ b/tests/storage/test_event_push_actions.py
@@ -16,8 +16,6 @@
 from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import MAIN_TIMELINE, RelationTypes
-from relapse.rest import admin
-from relapse.rest.client import login, room
 from relapse.server import HomeServer
 from relapse.storage.databases.main.event_push_actions import NotifCounts
 from relapse.types import JsonDict

--- a/tests/storage/test_event_push_actions.py
+++ b/tests/storage/test_event_push_actions.py
@@ -27,12 +27,6 @@ from tests.unittest import HomeserverTestCase
 
 
 class EventPushActionsStoreTestCase(HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.store = hs.get_datastores().main
         persist_events_store = hs.get_datastores().persist_events

--- a/tests/storage/test_events.py
+++ b/tests/storage/test_events.py
@@ -19,8 +19,6 @@ from relapse.api.constants import EventTypes, Membership
 from relapse.api.room_versions import RoomVersions
 from relapse.events import EventBase
 from relapse.federation.federation_base import event_from_pdu_json
-from relapse.rest import admin
-from relapse.rest.client import login, room
 from relapse.server import HomeServer
 from relapse.types import StateMap
 from relapse.util import Clock

--- a/tests/storage/test_events.py
+++ b/tests/storage/test_events.py
@@ -29,12 +29,6 @@ from tests.unittest import HomeserverTestCase
 
 
 class ExtremPruneTestCase(HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-    ]
-
     def prepare(
         self, reactor: MemoryReactor, clock: Clock, homeserver: HomeServer
     ) -> None:
@@ -365,12 +359,6 @@ class ExtremPruneTestCase(HomeserverTestCase):
 
 
 class InvalideUsersInRoomCacheTestCase(HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-    ]
-
     def prepare(
         self, reactor: MemoryReactor, clock: Clock, homeserver: HomeServer
     ) -> None:

--- a/tests/storage/test_purge.py
+++ b/tests/storage/test_purge.py
@@ -24,7 +24,6 @@ from tests.unittest import HomeserverTestCase
 
 class PurgeTests(HomeserverTestCase):
     user_id = "@red:server"
-    servlets = [room.register_servlets]
 
     def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
         hs = self.setup_test_homeserver("server")

--- a/tests/storage/test_purge.py
+++ b/tests/storage/test_purge.py
@@ -15,7 +15,6 @@
 from twisted.internet.testing import MemoryReactor
 
 from relapse.api.errors import NotFoundError, RelapseError
-from relapse.rest.client import room
 from relapse.server import HomeServer
 from relapse.util import Clock
 

--- a/tests/storage/test_room_search.py
+++ b/tests/storage/test_room_search.py
@@ -32,12 +32,6 @@ from tests.utils import USE_POSTGRES_FOR_TESTS
 
 
 class EventSearchInsertionTest(HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        room.register_servlets,
-    ]
-
     def test_null_byte(self) -> None:
         """
         Postgres/SQLite don't like null bytes going into the search tables. Internally
@@ -208,12 +202,6 @@ class MessageSearchTest(HomeserverTestCase):
     The result can be compared to the tokenized version for SQLite and Postgres < 11.
 
     """
-
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        room.register_servlets,
-    ]
 
     PHRASE = "the quick brown fox jumps over the lazy dog"
 

--- a/tests/storage/test_room_search.py
+++ b/tests/storage/test_room_search.py
@@ -18,8 +18,6 @@ from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EventTypes
 from relapse.api.errors import StoreError
-from relapse.rest import admin
-from relapse.rest.client import login, room
 from relapse.server import HomeServer
 from relapse.storage.databases.main import DataStore
 from relapse.storage.databases.main.search import Phrase, SearchToken, _tokenize_query

--- a/tests/storage/test_roommember.py
+++ b/tests/storage/test_roommember.py
@@ -29,12 +29,6 @@ from tests.test_utils import event_injection
 
 
 class RoomMemberStoreTestCase(unittest.HomeserverTestCase):
-    servlets = [
-        login.register_servlets,
-        admin.register_servlets,
-        room.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: TestHomeServer) -> None:  # type: ignore[override]
         # We can't test the RoomMemberStore on its own without the other event
         # storage logic

--- a/tests/storage/test_roommember.py
+++ b/tests/storage/test_roommember.py
@@ -17,8 +17,6 @@ from typing import cast
 from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import Membership
-from relapse.rest import admin
-from relapse.rest.client import login, room
 from relapse.server import HomeServer
 from relapse.types import UserID, create_requester
 from relapse.util import Clock

--- a/tests/storage/test_stream.py
+++ b/tests/storage/test_stream.py
@@ -34,12 +34,6 @@ class PaginationTestCase(HomeserverTestCase):
     we ensure that the filtering done in the database is applied successfully.
     """
 
-    servlets = [
-        admin.register_servlets,
-        room.register_servlets,
-        login.register_servlets,
-    ]
-
     def default_config(self) -> JsonDict:
         config = super().default_config()
         config["experimental_features"] = {"msc3874_enabled": True}

--- a/tests/storage/test_stream.py
+++ b/tests/storage/test_stream.py
@@ -17,8 +17,6 @@ from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import Direction, EventTypes, RelationTypes
 from relapse.api.filtering import Filter
-from relapse.rest import admin
-from relapse.rest.client import login, room
 from relapse.server import HomeServer
 from relapse.types import JsonDict
 from relapse.util import Clock

--- a/tests/storage/test_user_directory.py
+++ b/tests/storage/test_user_directory.py
@@ -128,13 +128,6 @@ class UserDirectoryInitialPopulationTestcase(HomeserverTestCase):
     test the incremental updates, rather than the big rebuild.
     """
 
-    servlets = [
-        login.register_servlets,
-        admin.register_servlets,
-        room.register_servlets,
-        register.register_servlets,
-    ]
-
     def make_homeserver(
         self, reactor: ThreadedMemoryReactorClock, clock: Clock
     ) -> HomeServer:

--- a/tests/storage/test_user_directory.py
+++ b/tests/storage/test_user_directory.py
@@ -19,8 +19,6 @@ from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EventTypes, Membership, UserTypes
 from relapse.appservice import ApplicationService
-from relapse.rest import admin
-from relapse.rest.client import login, register, room
 from relapse.server import HomeServer
 from relapse.storage import DataStore
 from relapse.storage.background_updates import _BackgroundUpdateHandler

--- a/tests/test_mau.py
+++ b/tests/test_mau.py
@@ -19,7 +19,6 @@ from twisted.internet.testing import MemoryReactor
 from relapse.api.constants import APP_SERVICE_REGISTRATION_TYPE, LoginType
 from relapse.api.errors import Codes, HttpResponseException, RelapseError
 from relapse.appservice import ApplicationService
-from relapse.rest.client import register, sync
 from relapse.server import HomeServer
 from relapse.types import JsonDict
 from relapse.util import Clock

--- a/tests/test_mau.py
+++ b/tests/test_mau.py
@@ -30,8 +30,6 @@ from tests.utils import default_config
 
 
 class TestMauLimit(unittest.HomeserverTestCase):
-    servlets = [register.register_servlets, sync.register_servlets]
-
     def default_config(self) -> JsonDict:
         config = default_config("test")
 

--- a/tests/test_phone_home.py
+++ b/tests/test_phone_home.py
@@ -18,8 +18,6 @@ from unittest import mock
 from twisted.internet.testing import MemoryReactor
 
 from relapse.app.phone_stats_home import phone_stats_home
-from relapse.rest import admin
-from relapse.rest.client import login, sync
 from relapse.server import HomeServer
 from relapse.types import JsonDict
 from relapse.util import Clock

--- a/tests/test_phone_home.py
+++ b/tests/test_phone_home.py
@@ -60,12 +60,6 @@ class PhoneHomeStatsTestCase(HomeserverTestCase):
 
 
 class CommonMetricsTestCase(HomeserverTestCase):
-    servlets = [
-        admin.register_servlets,
-        login.register_servlets,
-        sync.register_servlets,
-    ]
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.metrics_manager = hs.get_common_usage_metrics_manager()
         self.get_success(self.metrics_manager.setup())

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -19,12 +19,14 @@ from typing import NoReturn
 from twisted.internet.defer import Deferred
 
 from relapse.api.errors import Codes, RelapseError
-from relapse.http.server import JsonResource, respond_with_html_bytes
+from relapse.config.server import HttpResourceConfig
+from relapse.http.server import JsonResource
 from relapse.http.servlet import RestServlet
 from relapse.http.site import RelapseRequest
 from relapse.logging.context import make_deferred_yieldable
 from relapse.server import HomeServer
 from relapse.types import JsonDict
+from relapse.util import Clock
 from relapse.util.cancellation import cancellable
 
 from tests import unittest
@@ -32,6 +34,8 @@ from tests.http.server._base import test_disconnect
 from tests.server import (
     FakeChannel,
     FakeSite,
+    TestHomeServer,
+    ThreadedMemoryReactorClock,
     get_clock,
     make_request,
     setup_test_homeserver,
@@ -201,18 +205,6 @@ class JsonResourceTests(unittest.TestCase):
 
 
 class OptionsResourceTests(unittest.HomeserverTestCase):
-    class DummyServlet(RestServlet):
-        PATTERNS = [re.compile(r"^/_matrix/res/$")]
-
-        async def on_GET(self, request: RelapseRequest) -> None:
-            respond_with_html_bytes(request, 200, request.path)
-
-    servlets = [
-        lambda hs, http_server: OptionsResourceTests.DummyServlet().register(
-            http_server
-        )
-    ]
-
     def _check_cors_standard_headers(self, channel: FakeChannel) -> None:
         # Ensure the correct CORS headers have been added
         # as per https://spec.matrix.org/v1.4/client-server-api/#web-browser-clients
@@ -246,7 +238,7 @@ class OptionsResourceTests(unittest.HomeserverTestCase):
 
     def test_known_options_request(self) -> None:
         """An OPTIONS requests to an known URL still returns 204 No Content."""
-        channel = self.make_request("OPTIONS", "/_matrix/res/")
+        channel = self.make_request("OPTIONS", "/_matrix/client/versions")
         self.assertEqual(channel.code, 204)
         self.assertNotIn("body", channel.result)
 
@@ -259,9 +251,9 @@ class OptionsResourceTests(unittest.HomeserverTestCase):
 
     def test_known_request(self) -> None:
         """A non-OPTIONS request to an known URL should query the proper resource."""
-        channel = self.make_request("GET", "/_matrix/res/")
+        channel = self.make_request("GET", "/_matrix/client/versions")
         self.assertEqual(channel.code, 200)
-        self.assertEqual(channel.result["body"], b"/_matrix/res/")
+        self.assertIn("versions", channel.json_body)
 
 
 class CancellableRestServlet(RestServlet):
@@ -280,12 +272,23 @@ class CancellableRestServlet(RestServlet):
         return HTTPStatus.OK, {"result": True}
 
 
+class CancellableTestHomeserver(TestHomeServer):
+    def resource_for_listener(
+        self, resources: list[HttpResourceConfig]
+    ) -> JsonResource:
+        resource = JsonResource(self)
+        CancellableRestServlet(self).register(resource)
+        return resource
+
+
 class JsonResourceCancellationTests(unittest.HomeserverTestCase):
     """Tests for `JsonResource` cancellation."""
 
-    servlets = [
-        lambda hs, http_server: CancellableRestServlet(hs).register(http_server)
-    ]
+    def make_homeserver(
+        self, reactor: ThreadedMemoryReactorClock, clock: Clock
+    ) -> HomeServer:
+        # Override to load different servlets.
+        return self.setup_test_homeserver(homeserver_to_use=CancellableTestHomeserver)
 
     def test_cancellable_disconnect(self) -> None:
         """Test that handlers with the `@cancellable` flag can be cancelled."""

--- a/tests/test_terms_auth.py
+++ b/tests/test_terms_auth.py
@@ -17,7 +17,6 @@ from unittest.mock import Mock
 from twisted.internet.interfaces import IReactorTime
 from twisted.internet.testing import MemoryReactor, MemoryReactorClock
 
-from relapse.rest.client.register import register_servlets
 from relapse.server import HomeServer
 from relapse.types import JsonDict
 from relapse.util import Clock

--- a/tests/test_terms_auth.py
+++ b/tests/test_terms_auth.py
@@ -26,8 +26,6 @@ from tests import unittest
 
 
 class TermsTestCase(unittest.HomeserverTestCase):
-    servlets = [register_servlets]
-
     def default_config(self) -> JsonDict:
         config = super().default_config()
         config.update(

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -42,7 +42,6 @@ from twisted.internet.testing import MemoryReactor, MemoryReactorClock
 from twisted.python.failure import Failure
 from twisted.python.threadpool import ThreadPool
 from twisted.trial import unittest
-from twisted.web.resource import Resource
 from twisted.web.server import Request
 
 from relapse import events
@@ -52,7 +51,7 @@ from relapse.config._base import Config, RootConfig
 from relapse.config.homeserver import HomeServerConfig
 from relapse.config.server import DEFAULT_ROOM_VERSION
 from relapse.crypto.event_signing import add_hashes_and_signatures
-from relapse.http.server import HttpServer, OptionsResource
+from relapse.http.server import HttpServer
 from relapse.http.site import RelapseRequest, RelapseSite
 from relapse.logging.context import (
     SENTINEL_CONTEXT,
@@ -60,7 +59,6 @@ from relapse.logging.context import (
     current_context,
     set_current_context,
 )
-from relapse.rest import federation
 from relapse.server import HomeServer
 from relapse.storage.keys import FetchKeyResult
 from relapse.types import JsonDict, Requester, UserID, create_requester
@@ -341,11 +339,15 @@ class HomeserverTestCase(TestCase):
             raise Exception(f"A homeserver wasn't returned, but {self.hs!r}")
 
         # create the root resource, and a site to wrap it.
-        self.resource = self.create_test_resource(self.hs)
+        listener_config = self.hs.config.server.listeners[0]
+        assert listener_config.http_options is not None
+        self.resource = self.hs.resource_for_listener(
+            listener_config.http_options.resources
+        )
         self.site = RelapseSite(
             logger_name="relapse.access.http.fake",
             site_tag=self.hs.config.server.server_name,
-            config=self.hs.config.server.listeners[0],
+            config=listener_config,
             resource=self.resource,
             server_version_string="1",
             max_request_body_size=4096,
@@ -442,17 +444,7 @@ class HomeserverTestCase(TestCase):
 
         Function to be overridden in subclasses.
         """
-        hs = self.setup_test_homeserver()
-        return hs
-
-    def create_test_resource(self, hs: HomeServer) -> Resource:
-        """
-        Create the root resource for the test server.
-        """
-        root_resource = OptionsResource(hs)
-        for servlet in self.servlets:
-            servlet(hs, root_resource)
-        return root_resource
+        return self.setup_test_homeserver()
 
     def default_config(self) -> JsonDict:
         """
@@ -820,7 +812,10 @@ class FederatingHomeserverTestCase(HomeserverTestCase):
     OTHER_SERVER_NAME = "other.example.com"
     OTHER_SERVER_SIGNATURE_KEY = signedjson.key.generate_signing_key("test")
 
-    servlets = [federation.register_servlets]
+    def default_config(self) -> JsonDict:
+        config = super().default_config()
+        config["listeners"][0]["resources"][0]["names"].append("federation")
+        return config
 
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         super().prepare(reactor, clock, hs)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -197,7 +197,25 @@ def default_config(
         # (obviously) fake worker name disables updating the user directory.
         "update_user_directory_from_worker": "does_not_exist_worker_name",
         "caches": {"global_factor": 1, "sync_response_cache_duration": 0},
-        "listeners": [{"port": 0, "type": "http"}],
+        # Load almost all the resources.
+        "listeners": [
+            {
+                "port": 0,
+                "type": "http",
+                "resources": [
+                    {
+                        "names": [
+                            "client",
+                            "keys",
+                            "media",
+                            "metrics",
+                            "replication",
+                            "static"
+                        ]
+                    }
+                ],
+            }
+        ],
     }
 
     if parse:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -210,7 +210,7 @@ def default_config(
                             "media",
                             "metrics",
                             "replication",
-                            "static"
+                            "static",
                         ]
                     }
                 ],


### PR DESCRIPTION
This is a major simplification of servlets and how they get generated between the various homeserver objects and tests.