### PR TITLE
Consistently use NotFoundError/RedirectException

### DIFF
--- a/changelog.d/369.misc
+++ b/changelog.d/369.misc
@@ -1,0 +1,1 @@
+Clean up HTTP code.

--- a/relapse/api/errors.py
+++ b/relapse/api/errors.py
@@ -153,18 +153,18 @@ class RedirectException(CodeMessageException):
            b"sessionId=a3fWa; Expires=Wed, 21 Oct 2015 07:28:00 GMT"
     """
 
-    def __init__(self, location: bytes, http_code: int = http.FOUND):
+    def __init__(self, location: str, http_code: int = http.FOUND):
         """
 
         Args:
             location: the URI to redirect to
             http_code: the HTTP response code
         """
-        msg = "Redirect to {}".format(location.decode("utf-8"))
+        msg = f"Redirect to {location}"
         super().__init__(code=http_code, msg=msg)
-        self.location = location
+        self.location = location.encode("utf-8")
 
-        self.cookies: list[bytes] = []
+        self.cookies: dict[str, str] = {}
 
 
 class RelapseError(CodeMessageException):

--- a/relapse/handlers/auth.py
+++ b/relapse/handlers/auth.py
@@ -37,6 +37,7 @@ from relapse.api.errors import (
     InteractiveAuthIncompleteError,
     LoginError,
     NotFoundError,
+    RedirectException,
     RelapseError,
     StoreError,
 )
@@ -47,7 +48,7 @@ from relapse.handlers.ui_auth import (
 )
 from relapse.handlers.ui_auth.checkers import UserInteractiveAuthChecker
 from relapse.http import get_request_user_agent
-from relapse.http.server import finish_request, respond_with_html
+from relapse.http.server import respond_with_html
 from relapse.http.site import RelapseRequest
 from relapse.logging.context import defer_to_thread
 from relapse.metrics.background_process_metrics import run_as_background_process
@@ -1771,9 +1772,7 @@ class AuthHandler:
 
         # if the client is whitelisted, we can redirect straight to it
         if client_redirect_url.startswith(self._whitelisted_sso_clients):
-            request.redirect(redirect_url)
-            finish_request(request)
-            return
+            raise RedirectException(redirect_url)
 
         # Otherwise, serve the redirect confirmation page.
 

--- a/relapse/handlers/sso.py
+++ b/relapse/handlers/sso.py
@@ -32,7 +32,7 @@ from relapse.handlers.device import DeviceHandler
 from relapse.handlers.register import init_counters_for_auth_provider
 from relapse.handlers.ui_auth import UIAuthSessionDataConstants
 from relapse.http import get_request_user_agent
-from relapse.http.server import respond_with_html, respond_with_redirect
+from relapse.http.server import respond_with_html
 from relapse.http.site import RelapseRequest
 from relapse.types import (
     JsonDict,
@@ -170,7 +170,7 @@ class UsernameMappingSession:
 
 
 # the HTTP cookie used to track the mapping session id
-USERNAME_MAPPING_SESSION_COOKIE_NAME = b"username_mapping_session"
+USERNAME_MAPPING_SESSION_COOKIE_NAME = "username_mapping_session"
 
 
 class SsoHandler:
@@ -566,7 +566,7 @@ class SsoHandler:
         self,
         attributes: UserAttributes | None = None,
         session: UsernameMappingSession | None = None,
-    ) -> bytes:
+    ) -> str:
         """Returns the URL to redirect to for the next step of new user registration
 
         Given attributes from the user mapping provider or a UsernameMappingSession,
@@ -589,13 +589,13 @@ class SsoHandler:
             attributes
             and (attributes.localpart is None or attributes.confirm_localpart is True)
         ) or (session and session.chosen_localpart is None):
-            return b"/_relapse/client/pick_username/account_details"
+            return "/_relapse/client/pick_username/account_details"
         elif self._consent_at_registration and not (
             session and session.terms_accepted_version
         ):
-            return b"/_relapse/client/new_user_consent"
+            return "/_relapse/client/new_user_consent"
         else:
-            return b"/_relapse/client/sso_register" if session else b""
+            return "/_relapse/client/sso_register" if session else ""
 
     async def _redirect_to_next_new_user_step(
         self,
@@ -603,7 +603,7 @@ class SsoHandler:
         remote_user_id: str,
         attributes: UserAttributes,
         client_redirect_url: str,
-        next_step_url: bytes,
+        next_step_url: str,
         extra_login_attributes: JsonDict | None,
         auth_provider_session_id: str | None,
     ) -> NoReturn:
@@ -657,10 +657,7 @@ class SsoHandler:
 
         # Set the cookie and redirect to the next step
         e = RedirectException(next_step_url)
-        e.cookies.append(
-            b"%s=%s; path=/"
-            % (USERNAME_MAPPING_SESSION_COOKIE_NAME, session_id.encode("ascii"))
-        )
+        e.cookies[USERNAME_MAPPING_SESSION_COOKIE_NAME] = session_id
         raise e
 
     async def _register_mapped_user(
@@ -987,9 +984,7 @@ class SsoHandler:
                 )
         session.emails_to_use = filtered_emails
 
-        respond_with_redirect(
-            request, self._get_url_for_next_new_user_step(session=session)
-        )
+        raise RedirectException(self._get_url_for_next_new_user_step(session=session))
 
     async def handle_terms_accepted(
         self, request: RelapseRequest, session_id: str, terms_version: str
@@ -1017,9 +1012,7 @@ class SsoHandler:
 
         session.terms_accepted_version = terms_version
 
-        respond_with_redirect(
-            request, self._get_url_for_next_new_user_step(session=session)
-        )
+        raise RedirectException(self._get_url_for_next_new_user_step(session=session))
 
     async def register_sso_user(self, request: Request, session_id: str) -> None:
         """Called once we have all the info we need to register a new user.
@@ -1225,7 +1218,7 @@ def get_username_mapping_session_cookie_from_request(request: IRequest) -> str:
 
     Raises a RelapseError if the cookie isn't found
     """
-    session_id = request.getCookie(USERNAME_MAPPING_SESSION_COOKIE_NAME)
+    session_id = request.getCookie(USERNAME_MAPPING_SESSION_COOKIE_NAME.encode("ascii"))
     if not session_id:
         raise RelapseError(code=400, msg="missing session_id")
     return session_id.decode("ascii", errors="replace")

--- a/relapse/http/server.py
+++ b/relapse/http/server.py
@@ -21,7 +21,6 @@ import urllib
 import urllib.parse
 from collections.abc import Awaitable, Callable, Iterable, Iterator
 from http import HTTPStatus
-from http.client import FOUND
 from inspect import isawaitable
 from re import Pattern
 from typing import TYPE_CHECKING, Any, cast
@@ -98,7 +97,10 @@ def return_json_error(f: failure.Failure, request: "RelapseRequest") -> None:
         if isinstance(exc, RedirectException):
             logger.info("%s redirect to %s", request, exc.location)
             request.setHeader(b"location", exc.location)
-            request.cookies.extend(exc.cookies)
+            request.cookies.extend(
+                f"{name}={value}; path=/".encode("ascii")
+                for name, value in exc.cookies.items()
+            )
         elif isinstance(exc, RelapseError):
             error_dict = exc.error_dict()
             error_ctx = exc.debug_context
@@ -185,7 +187,10 @@ def return_html_error(
         if isinstance(cme, RedirectException):
             logger.info("%s redirect to %s", request, cme.location)
             request.setHeader(b"location", cme.location)
-            request.cookies.extend(cme.cookies)
+            request.cookies.extend(
+                f"{name}={value}; path=/".encode("ascii")
+                for name, value in cme.cookies.items()
+            )
         elif isinstance(cme, RelapseError):
             logger.info("%s RelapseError: %s - %s", request, code, msg)
         else:
@@ -869,28 +874,6 @@ def set_clickjacking_protection_headers(request: Request) -> None:
     """
     request.setHeader(b"X-Frame-Options", b"DENY")
     request.setHeader(b"Content-Security-Policy", b"frame-ancestors 'none';")
-
-
-def respond_with_redirect(
-    request: "RelapseRequest", url: bytes, statusCode: int = FOUND, cors: bool = False
-) -> None:
-    """
-    Write a 302 (or other specified status code) response to the request, if it is still alive.
-
-    Args:
-        request: The http request to respond to.
-        url: The URL to redirect to.
-        statusCode: The HTTP status code to use for the redirect (defaults to 302).
-        cors: Whether to set CORS headers on the response.
-    """
-    logger.debug("Redirect to %s", url.decode("utf-8"))
-
-    if cors:
-        set_cors_headers(request)
-
-    request.setResponseCode(statusCode)
-    request.setHeader(b"location", url)
-    finish_request(request)
 
 
 def finish_request(request: Request) -> None:

--- a/relapse/http/servlet.py
+++ b/relapse/http/servlet.py
@@ -839,7 +839,7 @@ class RedirectServlet(RestServlet):
         self.url = path
 
     async def on_GET(self, request: Request) -> NoReturn:
-        raise RedirectException(self.url.encode("ascii"))
+        raise RedirectException(self.url)
 
 
 class StaticServlet(RestServlet):

--- a/relapse/media/_base.py
+++ b/relapse/media/_base.py
@@ -26,8 +26,8 @@ from twisted.internet.interfaces import IConsumer
 from twisted.protocols.basic import FileSender
 from twisted.web.server import Request
 
-from relapse.api.errors import Codes, cs_error
-from relapse.http.server import finish_request, respond_with_json
+from relapse.api.errors import NotFoundError
+from relapse.http.server import finish_request
 from relapse.http.site import RelapseRequest
 from relapse.logging.context import make_deferred_yieldable
 from relapse.util.stringutils import is_ascii
@@ -90,16 +90,6 @@ DEFAULT_MAX_TIMEOUT_MS = 20_000
 MAXIMUM_ALLOWED_MAX_TIMEOUT_MS = 60_000
 
 
-def respond_404(request: RelapseRequest) -> None:
-    assert request.path is not None
-    respond_with_json(
-        request,
-        404,
-        cs_error(f"Not found '{request.path.decode()}'", code=Codes.NOT_FOUND),
-        send_cors=True,
-    )
-
-
 async def respond_with_file(
     request: RelapseRequest,
     media_type: str,
@@ -121,7 +111,7 @@ async def respond_with_file(
 
         finish_request(request)
     else:
-        respond_404(request)
+        raise NotFoundError()
 
 
 def add_file_headers(
@@ -265,8 +255,7 @@ async def respond_with_responder(
         upload_name: The name of the requested file, if any.
     """
     if not responder:
-        respond_404(request)
-        return
+        raise NotFoundError()
 
     # If we have a responder we *must* use it as a context manager.
     with responder:

--- a/relapse/media/media_repository.py
+++ b/relapse/media/media_repository.py
@@ -45,7 +45,6 @@ from relapse.media._base import (
     Responder,
     ThumbnailInfo,
     get_filename_from_headers,
-    respond_404,
     respond_with_responder,
 )
 from relapse.media.filepath import MediaFilePaths
@@ -380,13 +379,11 @@ class MediaRepository:
             media_info = await self.store.get_local_media(media_id)
             if not media_info:
                 logger.info("Media %s is unknown", media_id)
-                respond_404(request)
-                return None
+                raise NotFoundError()
 
             if media_info.quarantined_by:
                 logger.info("Media %s is quarantined", media_id)
-                respond_404(request)
-                return None
+                raise NotFoundError()
 
             # The file has been uploaded, so stop looping
             if media_info.media_length is not None:
@@ -397,8 +394,7 @@ class MediaRepository:
             expired_time_ms = now - self.unused_expiration_time
             if media_info.created_ts < expired_time_ms:
                 logger.info("Media %s has expired without being uploaded", media_id)
-                respond_404(request)
-                return None
+                raise NotFoundError()
 
             if now >= wait_until:
                 break
@@ -483,8 +479,7 @@ class MediaRepository:
         # block some servers' media from being accessible to local users.
         # See `prevent_media_downloads_from` config docs for more info.
         if server_name in self.prevent_media_downloads_from:
-            respond_404(request)
-            return
+            raise NotFoundError()
 
         self.mark_recently_accessed(server_name, media_id)
 
@@ -507,7 +502,7 @@ class MediaRepository:
                 upload_name,
             )
         else:
-            respond_404(request)
+            raise NotFoundError()
 
     async def get_remote_media_info(
         self, server_name: str, media_id: str, max_timeout_ms: int

--- a/relapse/rest/client/account.py
+++ b/relapse/rest/client/account.py
@@ -28,11 +28,12 @@ from relapse.api.errors import (
     Codes,
     InteractiveAuthIncompleteError,
     NotFoundError,
+    RedirectException,
     RelapseError,
     ThreepidValidationError,
 )
 from relapse.handlers.ui_auth import UIAuthSessionDataConstants
-from relapse.http.server import HttpServer, finish_request, respond_with_html
+from relapse.http.server import HttpServer, respond_with_html
 from relapse.http.servlet import (
     RestServlet,
     assert_params_in_dict,
@@ -511,10 +512,7 @@ class AddThreepidEmailSubmitTokenServlet(RestServlet):
 
             # Perform a 302 redirect if next_link is set
             if next_link:
-                request.setResponseCode(302)
-                request.setHeader("Location", next_link)
-                finish_request(request)
-                return None
+                raise RedirectException(next_link)
 
             # Otherwise show the success template
             html = self.config.email.email_add_threepid_template_success_html_content

--- a/relapse/rest/client/login.py
+++ b/relapse/rest/client/login.py
@@ -25,6 +25,7 @@ from relapse.api.errors import (
     InvalidClientTokenError,
     LoginError,
     NotApprovedError,
+    RedirectException,
     RelapseError,
     UserDeactivatedError,
 )
@@ -33,7 +34,7 @@ from relapse.api.urls import CLIENT_API_PREFIX
 from relapse.appservice import ApplicationService
 from relapse.handlers.sso import SsoIdentityProvider
 from relapse.http import get_request_uri
-from relapse.http.server import HttpServer, finish_request
+from relapse.http.server import HttpServer
 from relapse.http.servlet import (
     RestServlet,
     assert_params_in_dict,
@@ -645,9 +646,7 @@ class SsoRedirectServlet(RestServlet):
                 requested_uri.decode("utf-8", errors="replace"),
                 new_uri.decode("utf-8", errors="replace"),
             )
-            request.redirect(new_uri)
-            finish_request(request)
-            return
+            raise RedirectException(new_uri.decode("utf-8", errors="replace"))
 
         args: dict[bytes, list[bytes]] = request.args  # type: ignore
         client_redirect_url = parse_bytes_from_args(args, "redirectUrl", required=True)
@@ -657,8 +656,7 @@ class SsoRedirectServlet(RestServlet):
             idp_id,
         )
         logger.info("Redirecting to %s", sso_url)
-        request.redirect(sso_url)
-        finish_request(request)
+        raise RedirectException(sso_url)
 
 
 class CasTicketServlet(RestServlet):

--- a/relapse/rest/client/register.py
+++ b/relapse/rest/client/register.py
@@ -30,6 +30,7 @@ from relapse.api.errors import (
     Codes,
     InteractiveAuthIncompleteError,
     NotApprovedError,
+    RedirectException,
     RelapseError,
     ThreepidValidationError,
     UnrecognizedRequestError,
@@ -41,7 +42,7 @@ from relapse.config.ratelimiting import FederationRatelimitSettings
 from relapse.config.server import is_threepid_reserved
 from relapse.handlers.auth import AuthHandler
 from relapse.handlers.ui_auth import UIAuthSessionDataConstants
-from relapse.http.server import HttpServer, finish_request, respond_with_html
+from relapse.http.server import HttpServer, respond_with_html
 from relapse.http.servlet import (
     RestServlet,
     assert_params_in_dict,
@@ -284,10 +285,7 @@ class RegistrationSubmitTokenServlet(RestServlet):
                         "Not redirecting to next_link as it is a local file: address"
                     )
                 else:
-                    request.setResponseCode(302)
-                    request.setHeader("Location", next_link)
-                    finish_request(request)
-                    return None
+                    raise RedirectException(next_link)
 
             # Otherwise show the success template
             html = self.config.email.email_registration_template_success_html_content

--- a/relapse/rest/media/download.py
+++ b/relapse/rest/media/download.py
@@ -16,13 +16,13 @@ import logging
 import re
 from typing import TYPE_CHECKING
 
+from relapse.api.errors import NotFoundError
 from relapse.http.server import set_corp_headers, set_cors_headers
 from relapse.http.servlet import RestServlet, parse_boolean, parse_integer
 from relapse.http.site import RelapseRequest
 from relapse.media._base import (
     DEFAULT_MAX_TIMEOUT_MS,
     MAXIMUM_ALLOWED_MAX_TIMEOUT_MS,
-    respond_404,
 )
 from relapse.util.stringutils import parse_and_validate_server_name
 
@@ -87,8 +87,7 @@ class DownloadServlet(RestServlet):
                     server_name,
                     media_id,
                 )
-                respond_404(request)
-                return
+                raise NotFoundError()
 
             await self.media_repo.get_remote_media(
                 request, server_name, media_id, file_name, max_timeout_ms

--- a/relapse/rest/media/thumbnail.py
+++ b/relapse/rest/media/thumbnail.py
@@ -17,7 +17,7 @@ import logging
 import re
 from typing import TYPE_CHECKING
 
-from relapse.api.errors import Codes, RelapseError, cs_error
+from relapse.api.errors import Codes, NotFoundError, RelapseError, cs_error
 from relapse.config.repository import THUMBNAIL_SUPPORTED_MEDIA_FORMAT_MAP
 from relapse.http.server import respond_with_json, set_corp_headers, set_cors_headers
 from relapse.http.servlet import RestServlet, parse_integer, parse_string
@@ -27,7 +27,6 @@ from relapse.media._base import (
     MAXIMUM_ALLOWED_MAX_TIMEOUT_MS,
     FileInfo,
     ThumbnailInfo,
-    respond_404,
     respond_with_file,
     respond_with_responder,
 )
@@ -98,8 +97,7 @@ class ThumbnailServlet(RestServlet):
             # media inaccessible to local users.
             # See `prevent_media_downloads_from` config docs for more info.
             if server_name in self.prevent_media_downloads_from:
-                respond_404(request)
-                return
+                raise NotFoundError()
 
             remote_resp_function = (
                 self._select_or_generate_remote_thumbnail
@@ -220,8 +218,7 @@ class ThumbnailServlet(RestServlet):
             server_name, media_id, max_timeout_ms
         )
         if not media_info:
-            respond_404(request)
-            return
+            raise NotFoundError()
 
         thumbnail_infos = await self.store.get_remote_media_thumbnails(
             server_name, media_id
@@ -357,8 +354,7 @@ class ThumbnailServlet(RestServlet):
             )
             if not file_info:
                 logger.info("Couldn't find a thumbnail matching the desired inputs")
-                respond_404(request)
-                return
+                raise NotFoundError()
 
             # The thumbnail property must exist.
             assert file_info.thumbnail is not None

--- a/relapse/rest/relapse/client/password_reset.py
+++ b/relapse/rest/relapse/client/password_reset.py
@@ -96,8 +96,7 @@ class PasswordResetSubmitTokenServlet(RestServlet):
                         "Not redirecting to next_link as it is a local file: address"
                     )
                 else:
-                    next_link_bytes = next_link.encode("utf-8")
-                    raise RedirectException(next_link_bytes)
+                    raise RedirectException(next_link)
 
             # Otherwise show the success template
             html = self._email_password_reset_template_success_html

--- a/relapse/rest/relapse/client/pick_idp.py
+++ b/relapse/rest/relapse/client/pick_idp.py
@@ -15,7 +15,8 @@ import logging
 import re
 from typing import TYPE_CHECKING
 
-from relapse.http.server import finish_request, respond_with_html
+from relapse.api.errors import RedirectException
+from relapse.http.server import respond_with_html
 from relapse.http.servlet import RestServlet, parse_string
 from relapse.http.site import RelapseRequest
 
@@ -65,8 +66,7 @@ class PickIdpServlet(RestServlet):
             request, client_redirect_url.encode("utf8")
         )
         logger.info("Redirecting to %s", sso_url)
-        request.redirect(sso_url)
-        finish_request(request)
+        raise RedirectException(sso_url)
 
     async def _serve_id_picker(
         self, request: RelapseRequest, client_redirect_url: str

--- a/tests/handlers/test_saml.py
+++ b/tests/handlers/test_saml.py
@@ -91,7 +91,7 @@ class TestRedirectMappingProvider(TestMappingProvider):
         failures: int,
         client_redirect_url: str,
     ) -> dict:
-        raise RedirectException(b"https://custom-saml-redirect/")
+        raise RedirectException("https://custom-saml-redirect/")
 
 
 class SamlHandlerTestCase(HomeserverTestCase):

--- a/tests/media/test_media_storage.py
+++ b/tests/media/test_media_storage.py
@@ -586,11 +586,7 @@ class MediaRepoTests(unittest.HomeserverTestCase):
             # A 404 with a JSON body.
             self.assertEqual(channel.code, 404)
             self.assertEqual(
-                channel.json_body,
-                {
-                    "errcode": "M_NOT_FOUND",
-                    "error": "Not found '/_matrix/media/r0/thumbnail/example.com/12345'",
-                },
+                channel.json_body, {"errcode": "M_NOT_FOUND", "error": "Not found"}
             )
 
     @parameterized.expand([("crop", 16), ("crop", 64), ("scale", 16), ("scale", 64)])


### PR DESCRIPTION
Cleans up some usage of HTTP APIs.