### PR TITLE
Remove some unnecessary Twisted constructs

### DIFF
--- a/changelog.d/380.misc
+++ b/changelog.d/380.misc
@@ -1,0 +1,1 @@
+Improve testing infrastructure.

--- a/relapse/_scripts/relapse_port_db.py
+++ b/relapse/_scripts/relapse_port_db.py
@@ -22,14 +22,14 @@ import os
 import sys
 import time
 import traceback
-from collections.abc import Awaitable, Callable, Generator, Iterable
+from collections.abc import Awaitable, Callable, Iterable
 from types import TracebackType
 from typing import Any, NoReturn, Optional, TypeVar, cast
 
 import yaml
 from typing_extensions import TypedDict
 
-from twisted.internet import defer, reactor as reactor_
+from twisted.internet import defer, reactor as reactor_, task
 
 from relapse.config.database import DatabaseConnectionConfig
 from relapse.config.homeserver import HomeServerConfig
@@ -1389,14 +1389,11 @@ def main() -> None:
             hs_config=config,
         )
 
-        @defer.inlineCallbacks
-        def run() -> Generator["defer.Deferred[Any]", Any, None]:
+        async def run() -> None:
             with LoggingContext("relapse_port_db_run"):
-                yield defer.ensureDeferred(porter.run())
+                await porter.run()
 
-        reactor.callWhenRunning(run)
-
-        reactor.run()
+        task.react(run)
 
     if args.curses:
         curses.wrapper(start)

--- a/relapse/module_api/__init__.py
+++ b/relapse/module_api/__init__.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 import email.utils
 import logging
-from collections.abc import Callable, Collection, Generator, Iterable, Mapping
+from collections.abc import Callable, Collection, Iterable, Mapping
 from typing import TYPE_CHECKING, Any, Concatenate, TypeVar
 
 import attr
@@ -678,13 +678,12 @@ class ModuleApi:
         """
         return defer.ensureDeferred(self._auth_handler.check_user_exists(user_id))
 
-    @defer.inlineCallbacks
-    def register(
+    async def register(
         self,
         localpart: str,
         displayname: str | None = None,
         emails: list[str] | None = None,
-    ) -> Generator["defer.Deferred[Any]", Any, tuple[str, str]]:
+    ) -> tuple[str, str]:
         """Registers a new user with given localpart and optional displayname, emails.
 
         Also returns an access token for the new user.
@@ -706,8 +705,8 @@ class ModuleApi:
         logger.warning(
             "Using deprecated ModuleApi.register which creates a dummy user device."
         )
-        user_id = yield self.register_user(localpart, displayname, emails or [])
-        _, access_token, _, _ = yield self.register_device(user_id)
+        user_id = await self.register_user(localpart, displayname, emails or [])
+        _, access_token, _, _ = await self.register_device(user_id)
         return user_id, access_token
 
     def register_user(
@@ -825,10 +824,7 @@ class ModuleApi:
             auth_provider_session_id,
         )
 
-    @defer.inlineCallbacks
-    def invalidate_access_token(
-        self, access_token: str
-    ) -> Generator["defer.Deferred[Any]", Any, None]:
+    async def invalidate_access_token(self, access_token: str) -> None:
         """Invalidate an access token for a user
 
         Can only be called from the main process.
@@ -850,21 +846,15 @@ class ModuleApi:
         )
 
         # see if the access token corresponds to a device
-        user_info = yield defer.ensureDeferred(
-            self._auth.get_user_by_access_token(access_token)
-        )
-        device_id = user_info.get("device_id")
-        user_id = user_info["user"].to_string()
+        user_info = await self._auth.get_user_by_access_token(access_token)
+        device_id = user_info.device_id
+        user_id = user_info.user.to_string()
         if device_id:
             # delete the device, which will also delete its access tokens
-            yield defer.ensureDeferred(
-                self._device_handler.delete_devices(user_id, [device_id])
-            )
+            await self._device_handler.delete_devices(user_id, [device_id])
         else:
             # no associated device. Just delete the access token.
-            yield defer.ensureDeferred(
-                self._auth_handler.delete_access_token(access_token)
-            )
+            await self._auth_handler.delete_access_token(access_token)
 
     def run_db_interaction(
         self,
@@ -960,10 +950,9 @@ class ModuleApi:
             new_user=new_user,
         )
 
-    @defer.inlineCallbacks
-    def get_state_events_in_room(
+    async def get_state_events_in_room(
         self, room_id: str, types: Iterable[tuple[str, str | None]]
-    ) -> Generator[defer.Deferred, Any, Iterable[EventBase]]:
+    ) -> Iterable[EventBase]:
         """Gets current state events for the given room.
 
         (This is exposed for compatibility with the old SpamCheckerApi. We should
@@ -979,12 +968,10 @@ class ModuleApi:
         Returns:
             The filtered state events in the room.
         """
-        state_ids = yield defer.ensureDeferred(
-            self._storage_controllers.state.get_current_state_ids(
-                room_id=room_id, state_filter=StateFilter.from_types(types)
-            )
+        state_ids = await self._storage_controllers.state.get_current_state_ids(
+            room_id=room_id, state_filter=StateFilter.from_types(types)
         )
-        state = yield defer.ensureDeferred(self._store.get_events(state_ids.values()))
+        state = await self._store.get_events(state_ids.values())
         return state.values()
 
     async def update_room_membership(

--- a/tests/appservice/test_appservice.py
+++ b/tests/appservice/test_appservice.py
@@ -12,11 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import re
-from collections.abc import Generator
-from typing import Any
 from unittest.mock import AsyncMock, Mock
-
-from twisted.internet import defer
 
 from relapse.appservice import ApplicationService, Namespace
 
@@ -46,84 +42,58 @@ class ApplicationServiceTestCase(unittest.TestCase):
         self.store.get_aliases_for_room = AsyncMock(return_value=[])
         self.store.get_local_users_in_room = AsyncMock(return_value=[])
 
-    @defer.inlineCallbacks
-    def test_regex_user_id_prefix_match(
-        self,
-    ) -> Generator["defer.Deferred[Any]", object, None]:
+    async def test_regex_user_id_prefix_match(self) -> None:
         self.service.namespaces[ApplicationService.NS_USERS].append(_regex("@irc_.*"))
         self.event.sender = "@irc_foobar:matrix.org"
         self.assertTrue(
-            (
-                yield self.service.is_interested_in_event(
-                    self.event.event_id, self.event, self.store
-                )
+            await self.service.is_interested_in_event(
+                self.event.event_id, self.event, self.store
             )
         )
 
-    @defer.inlineCallbacks
-    def test_regex_user_id_prefix_no_match(
-        self,
-    ) -> Generator["defer.Deferred[Any]", object, None]:
+    async def test_regex_user_id_prefix_no_match(self) -> None:
         self.service.namespaces[ApplicationService.NS_USERS].append(_regex("@irc_.*"))
         self.event.sender = "@someone_else:matrix.org"
         self.assertFalse(
-            (
-                yield self.service.is_interested_in_event(
-                    self.event.event_id, self.event, self.store
-                )
+            await self.service.is_interested_in_event(
+                self.event.event_id, self.event, self.store
             )
         )
 
-    @defer.inlineCallbacks
-    def test_regex_room_member_is_checked(
-        self,
-    ) -> Generator["defer.Deferred[Any]", object, None]:
+    async def test_regex_room_member_is_checked(self) -> None:
         self.service.namespaces[ApplicationService.NS_USERS].append(_regex("@irc_.*"))
         self.event.sender = "@someone_else:matrix.org"
         self.event.type = "m.room.member"
         self.event.state_key = "@irc_foobar:matrix.org"
         self.assertTrue(
-            (
-                yield self.service.is_interested_in_event(
-                    self.event.event_id, self.event, self.store
-                )
+            await self.service.is_interested_in_event(
+                self.event.event_id, self.event, self.store
             )
         )
 
-    @defer.inlineCallbacks
-    def test_regex_room_id_match(
-        self,
-    ) -> Generator["defer.Deferred[Any]", object, None]:
+    async def test_regex_room_id_match(self) -> None:
         self.service.namespaces[ApplicationService.NS_ROOMS].append(
             _regex("!some_prefix.*some_suffix:matrix.org")
         )
         self.event.room_id = "!some_prefixs0m3th1nGsome_suffix:matrix.org"
         self.assertTrue(
-            (
-                yield self.service.is_interested_in_event(
-                    self.event.event_id, self.event, self.store
-                )
+            await self.service.is_interested_in_event(
+                self.event.event_id, self.event, self.store
             )
         )
 
-    @defer.inlineCallbacks
-    def test_regex_room_id_no_match(
-        self,
-    ) -> Generator["defer.Deferred[Any]", object, None]:
+    async def test_regex_room_id_no_match(self) -> None:
         self.service.namespaces[ApplicationService.NS_ROOMS].append(
             _regex("!some_prefix.*some_suffix:matrix.org")
         )
         self.event.room_id = "!XqBunHwQIXUiqCaoxq:matrix.org"
         self.assertFalse(
-            (
-                yield self.service.is_interested_in_event(
-                    self.event.event_id, self.event, self.store
-                )
+            await self.service.is_interested_in_event(
+                self.event.event_id, self.event, self.store
             )
         )
 
-    @defer.inlineCallbacks
-    def test_regex_alias_match(self) -> Generator["defer.Deferred[Any]", object, None]:
+    async def test_regex_alias_match(self) -> None:
         self.service.namespaces[ApplicationService.NS_ALIASES].append(
             _regex("#irc_.*:matrix.org")
         )
@@ -132,10 +102,8 @@ class ApplicationServiceTestCase(unittest.TestCase):
         )
         self.store.get_local_users_in_room = AsyncMock(return_value=[])
         self.assertTrue(
-            (
-                yield self.service.is_interested_in_event(
-                    self.event.event_id, self.event, self.store
-                )
+            await self.service.is_interested_in_event(
+                self.event.event_id, self.event, self.store
             )
         )
 
@@ -175,10 +143,7 @@ class ApplicationServiceTestCase(unittest.TestCase):
         )
         self.assertTrue(self.service.is_exclusive_room("!irc_foobar:matrix.org"))
 
-    @defer.inlineCallbacks
-    def test_regex_alias_no_match(
-        self,
-    ) -> Generator["defer.Deferred[Any]", object, None]:
+    async def test_regex_alias_no_match(self) -> None:
         self.service.namespaces[ApplicationService.NS_ALIASES].append(
             _regex("#irc_.*:matrix.org")
         )
@@ -187,19 +152,12 @@ class ApplicationServiceTestCase(unittest.TestCase):
         )
         self.store.get_local_users_in_room = AsyncMock(return_value=[])
         self.assertFalse(
-            (
-                yield defer.ensureDeferred(
-                    self.service.is_interested_in_event(
-                        self.event.event_id, self.event, self.store
-                    )
-                )
+            await self.service.is_interested_in_event(
+                self.event.event_id, self.event, self.store
             )
         )
 
-    @defer.inlineCallbacks
-    def test_regex_multiple_matches(
-        self,
-    ) -> Generator["defer.Deferred[Any]", object, None]:
+    async def test_regex_multiple_matches(self) -> None:
         self.service.namespaces[ApplicationService.NS_ALIASES].append(
             _regex("#irc_.*:matrix.org")
         )
@@ -210,15 +168,12 @@ class ApplicationServiceTestCase(unittest.TestCase):
         )
         self.store.get_local_users_in_room = AsyncMock(return_value=[])
         self.assertTrue(
-            (
-                yield self.service.is_interested_in_event(
-                    self.event.event_id, self.event, self.store
-                )
+            await self.service.is_interested_in_event(
+                self.event.event_id, self.event, self.store
             )
         )
 
-    @defer.inlineCallbacks
-    def test_interested_in_self(self) -> Generator["defer.Deferred[Any]", object, None]:
+    async def test_interested_in_self(self) -> None:
         # make sure invites get through
         self.service.sender = "@appservice:name"
         self.service.namespaces[ApplicationService.NS_USERS].append(_regex("@irc_.*"))
@@ -226,15 +181,12 @@ class ApplicationServiceTestCase(unittest.TestCase):
         self.event.content = {"membership": "invite"}
         self.event.state_key = self.service.sender
         self.assertTrue(
-            (
-                yield self.service.is_interested_in_event(
-                    self.event.event_id, self.event, self.store
-                )
+            await self.service.is_interested_in_event(
+                self.event.event_id, self.event, self.store
             )
         )
 
-    @defer.inlineCallbacks
-    def test_member_list_match(self) -> Generator["defer.Deferred[Any]", object, None]:
+    async def test_member_list_match(self) -> None:
         self.service.namespaces[ApplicationService.NS_USERS].append(_regex("@irc_.*"))
         # Note that @irc_fo:here is the AS user.
         self.store.get_local_users_in_room = AsyncMock(
@@ -244,9 +196,7 @@ class ApplicationServiceTestCase(unittest.TestCase):
 
         self.event.sender = "@xmpp_foobar:matrix.org"
         self.assertTrue(
-            (
-                yield self.service.is_interested_in_event(
-                    self.event.event_id, self.event, self.store
-                )
+            await self.service.is_interested_in_event(
+                self.event.event_id, self.event, self.store
             )
         )

--- a/tests/appservice/test_scheduler.py
+++ b/tests/appservice/test_scheduler.py
@@ -52,7 +52,7 @@ class ApplicationServiceSchedulerTransactionCtrlTestCase(unittest.TestCase):
         )
         self.txnctrl.RECOVERER_CLASS = self.recoverer_fn
 
-    def test_single_service_up_txn_sent(self) -> None:
+    async def test_single_service_up_txn_sent(self) -> None:
         # Test: The AS is up and the txn is successfully sent.
         service = Mock()
         events = [Mock(), Mock()]
@@ -68,7 +68,7 @@ class ApplicationServiceSchedulerTransactionCtrlTestCase(unittest.TestCase):
         self.store.create_appservice_txn = AsyncMock(return_value=txn)
 
         # actual call
-        self.successResultOf(defer.ensureDeferred(self.txnctrl.send(service, events)))
+        await defer.ensureDeferred(self.txnctrl.send(service, events))
 
         self.store.create_appservice_txn.assert_called_once_with(
             service=service,
@@ -82,7 +82,7 @@ class ApplicationServiceSchedulerTransactionCtrlTestCase(unittest.TestCase):
         self.assertEqual(0, len(self.txnctrl.recoverers))  # no recoverer made
         txn.complete.assert_called_once_with(self.store)  # txn completed
 
-    def test_single_service_down(self) -> None:
+    async def test_single_service_down(self) -> None:
         # Test: The AS is down so it shouldn't push; Recoverers will do it.
         # It should still make a transaction though.
         service = Mock()
@@ -95,7 +95,7 @@ class ApplicationServiceSchedulerTransactionCtrlTestCase(unittest.TestCase):
         self.store.create_appservice_txn = AsyncMock(return_value=txn)
 
         # actual call
-        self.successResultOf(defer.ensureDeferred(self.txnctrl.send(service, events)))
+        await defer.ensureDeferred(self.txnctrl.send(service, events))
 
         self.store.create_appservice_txn.assert_called_once_with(
             service=service,
@@ -109,7 +109,7 @@ class ApplicationServiceSchedulerTransactionCtrlTestCase(unittest.TestCase):
         self.assertEqual(0, txn.send.call_count)  # txn not sent though
         self.assertEqual(0, txn.complete.call_count)  # or completed
 
-    def test_single_service_up_txn_not_sent(self) -> None:
+    async def test_single_service_up_txn_not_sent(self) -> None:
         # Test: The AS is up and the txn is not sent. A Recoverer is made and
         # started.
         service = Mock()
@@ -126,7 +126,7 @@ class ApplicationServiceSchedulerTransactionCtrlTestCase(unittest.TestCase):
         self.store.create_appservice_txn = AsyncMock(return_value=txn)
 
         # actual call
-        self.successResultOf(defer.ensureDeferred(self.txnctrl.send(service, events)))
+        await defer.ensureDeferred(self.txnctrl.send(service, events))
 
         self.store.create_appservice_txn.assert_called_once_with(
             service=service,

--- a/tests/federation/test_federation_sender.py
+++ b/tests/federation/test_federation_sender.py
@@ -175,7 +175,7 @@ class FederationSenderReceiptsTestCases(HomeserverTestCase):
             ],
         )
 
-    def test_send_receipts_with_backoff(self) -> None:
+    async def test_send_receipts_with_backoff(self) -> None:
         """Send two receipts in quick succession; the second should be flushed, but
         only after 20ms"""
         mock_send_transaction = self.federation_client.send_transaction
@@ -227,7 +227,7 @@ class FederationSenderReceiptsTestCases(HomeserverTestCase):
             thread_id=None,
             data={"ts": 1234},
         )
-        self.successResultOf(defer.ensureDeferred(sender.send_read_receipt(receipt)))
+        await defer.ensureDeferred(sender.send_read_receipt(receipt))
         self.pump()
         mock_send_transaction.assert_not_called()
 

--- a/tests/handlers/test_appservice.py
+++ b/tests/handlers/test_appservice.py
@@ -17,7 +17,6 @@ from unittest.mock import AsyncMock, Mock
 
 from parameterized import parameterized
 
-from twisted.internet import defer
 from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EduTypes, EventTypes
@@ -135,7 +134,7 @@ class AppServiceHandlerTestCase(unittest.TestCase):
             "query_user called when it shouldn't have been.",
         )
 
-    def test_query_room_alias_exists(self) -> None:
+    async def test_query_room_alias_exists(self) -> None:
         room_alias_str = "#foo:bar"
         room_alias = Mock()
         room_alias.to_string.return_value = room_alias_str
@@ -155,9 +154,7 @@ class AppServiceHandlerTestCase(unittest.TestCase):
             return_value=Mock(room_id=room_id, servers=servers)
         )
 
-        result = self.successResultOf(
-            defer.ensureDeferred(self.handler.query_room_alias_exists(room_alias))
-        )
+        result = await self.handler.query_room_alias_exists(room_alias)
         assert result is not None
 
         self.mock_as_api.query_alias.assert_called_once_with(
@@ -166,45 +163,37 @@ class AppServiceHandlerTestCase(unittest.TestCase):
         self.assertEqual(result.room_id, room_id)
         self.assertEqual(result.servers, servers)
 
-    def test_get_3pe_protocols_no_appservices(self) -> None:
+    async def test_get_3pe_protocols_no_appservices(self) -> None:
         self.mock_store.get_app_services.return_value = []
-        response = self.successResultOf(
-            defer.ensureDeferred(self.handler.get_3pe_protocols("my-protocol"))
-        )
+        response = await self.handler.get_3pe_protocols("my-protocol")
         self.mock_as_api.get_3pe_protocol.assert_not_called()
         self.assertEqual(response, {})
 
-    def test_get_3pe_protocols_no_protocols(self) -> None:
+    async def test_get_3pe_protocols_no_protocols(self) -> None:
         service = self._mkservice(False, [])
         self.mock_store.get_app_services.return_value = [service]
-        response = self.successResultOf(
-            defer.ensureDeferred(self.handler.get_3pe_protocols())
-        )
+        response = await self.handler.get_3pe_protocols()
         self.mock_as_api.get_3pe_protocol.assert_not_called()
         self.assertEqual(response, {})
 
-    def test_get_3pe_protocols_protocol_no_response(self) -> None:
+    async def test_get_3pe_protocols_protocol_no_response(self) -> None:
         service = self._mkservice(False, ["my-protocol"])
         self.mock_store.get_app_services.return_value = [service]
         self.mock_as_api.get_3pe_protocol.return_value = None
-        response = self.successResultOf(
-            defer.ensureDeferred(self.handler.get_3pe_protocols())
-        )
+        response = await self.handler.get_3pe_protocols()
         self.mock_as_api.get_3pe_protocol.assert_called_once_with(
             service, "my-protocol"
         )
         self.assertEqual(response, {})
 
-    def test_get_3pe_protocols_select_one_protocol(self) -> None:
+    async def test_get_3pe_protocols_select_one_protocol(self) -> None:
         service = self._mkservice(False, ["my-protocol"])
         self.mock_store.get_app_services.return_value = [service]
         self.mock_as_api.get_3pe_protocol.return_value = {
             "x-protocol-data": 42,
             "instances": [],
         }
-        response = self.successResultOf(
-            defer.ensureDeferred(self.handler.get_3pe_protocols("my-protocol"))
-        )
+        response = await self.handler.get_3pe_protocols("my-protocol")
         self.mock_as_api.get_3pe_protocol.assert_called_once_with(
             service, "my-protocol"
         )
@@ -212,16 +201,14 @@ class AppServiceHandlerTestCase(unittest.TestCase):
             response, {"my-protocol": {"x-protocol-data": 42, "instances": []}}
         )
 
-    def test_get_3pe_protocols_one_protocol(self) -> None:
+    async def test_get_3pe_protocols_one_protocol(self) -> None:
         service = self._mkservice(False, ["my-protocol"])
         self.mock_store.get_app_services.return_value = [service]
         self.mock_as_api.get_3pe_protocol.return_value = {
             "x-protocol-data": 42,
             "instances": [],
         }
-        response = self.successResultOf(
-            defer.ensureDeferred(self.handler.get_3pe_protocols())
-        )
+        response = await self.handler.get_3pe_protocols()
         self.mock_as_api.get_3pe_protocol.assert_called_once_with(
             service, "my-protocol"
         )
@@ -229,7 +216,7 @@ class AppServiceHandlerTestCase(unittest.TestCase):
             response, {"my-protocol": {"x-protocol-data": 42, "instances": []}}
         )
 
-    def test_get_3pe_protocols_multiple_protocol(self) -> None:
+    async def test_get_3pe_protocols_multiple_protocol(self) -> None:
         service_one = self._mkservice(False, ["my-protocol"])
         service_two = self._mkservice(False, ["other-protocol"])
         self.mock_store.get_app_services.return_value = [service_one, service_two]
@@ -237,9 +224,7 @@ class AppServiceHandlerTestCase(unittest.TestCase):
             "x-protocol-data": 42,
             "instances": [],
         }
-        response = self.successResultOf(
-            defer.ensureDeferred(self.handler.get_3pe_protocols())
-        )
+        response = await self.handler.get_3pe_protocols()
         self.mock_as_api.get_3pe_protocol.assert_called()
         self.assertEqual(
             response,
@@ -249,7 +234,7 @@ class AppServiceHandlerTestCase(unittest.TestCase):
             },
         )
 
-    def test_get_3pe_protocols_multiple_info(self) -> None:
+    async def test_get_3pe_protocols_multiple_info(self) -> None:
         service_one = self._mkservice(False, ["my-protocol"])
         service_two = self._mkservice(False, ["my-protocol"])
 
@@ -271,9 +256,7 @@ class AppServiceHandlerTestCase(unittest.TestCase):
 
         self.mock_store.get_app_services.return_value = [service_one, service_two]
         self.mock_as_api.get_3pe_protocol = get_3pe_protocol
-        response = self.successResultOf(
-            defer.ensureDeferred(self.handler.get_3pe_protocols())
-        )
+        response = await self.handler.get_3pe_protocols()
         # It's expected that the second service's data doesn't appear in the response
         self.assertEqual(
             response,

--- a/tests/handlers/test_oauth_delegation.py
+++ b/tests/handlers/test_oauth_delegation.py
@@ -42,7 +42,7 @@ from relapse.types import JsonDict, UserID
 from relapse.util import Clock
 
 from tests.server import FakeChannel
-from tests.test_utils import FakeResponse, get_awaitable_result
+from tests.test_utils import FakeResponse
 from tests.unittest import HomeserverTestCase, override_config, skip_unless
 from tests.utils import HAS_AUTHLIB, checked_cast, mock_getRawHeaders
 
@@ -238,7 +238,7 @@ class MSC3861OAuthDelegation(HomeserverTestCase):
         )
         self._assertParams()
 
-    def test_active_admin(self) -> None:
+    async def test_active_admin(self) -> None:
         """The handler should return a requester with admin rights."""
 
         self.http_client.request = AsyncMock(
@@ -264,11 +264,9 @@ class MSC3861OAuthDelegation(HomeserverTestCase):
         self.assertEqual(requester.user.to_string(), f"@{USERNAME}:{SERVER_NAME}")
         self.assertEqual(requester.is_guest, False)
         self.assertEqual(requester.device_id, None)
-        self.assertEqual(
-            get_awaitable_result(self.auth.is_server_admin(requester)), True
-        )
+        self.assertEqual(await self.auth.is_server_admin(requester), True)
 
-    def test_active_admin_highest_privilege(self) -> None:
+    async def test_active_admin_highest_privilege(self) -> None:
         """The handler should resolve to the most permissive scope."""
 
         self.http_client.request = AsyncMock(
@@ -296,11 +294,9 @@ class MSC3861OAuthDelegation(HomeserverTestCase):
         self.assertEqual(requester.user.to_string(), f"@{USERNAME}:{SERVER_NAME}")
         self.assertEqual(requester.is_guest, False)
         self.assertEqual(requester.device_id, None)
-        self.assertEqual(
-            get_awaitable_result(self.auth.is_server_admin(requester)), True
-        )
+        self.assertEqual(await self.auth.is_server_admin(requester), True)
 
-    def test_active_user(self) -> None:
+    async def test_active_user(self) -> None:
         """The handler should return a requester with normal user rights."""
 
         self.http_client.request = AsyncMock(
@@ -326,11 +322,9 @@ class MSC3861OAuthDelegation(HomeserverTestCase):
         self.assertEqual(requester.user.to_string(), f"@{USERNAME}:{SERVER_NAME}")
         self.assertEqual(requester.is_guest, False)
         self.assertEqual(requester.device_id, None)
-        self.assertEqual(
-            get_awaitable_result(self.auth.is_server_admin(requester)), False
-        )
+        self.assertEqual(await self.auth.is_server_admin(requester), False)
 
-    def test_active_user_with_device(self) -> None:
+    async def test_active_user_with_device(self) -> None:
         """The handler should return a requester with normal user rights and a device ID."""
 
         self.http_client.request = AsyncMock(
@@ -355,9 +349,7 @@ class MSC3861OAuthDelegation(HomeserverTestCase):
         self._assertParams()
         self.assertEqual(requester.user.to_string(), f"@{USERNAME}:{SERVER_NAME}")
         self.assertEqual(requester.is_guest, False)
-        self.assertEqual(
-            get_awaitable_result(self.auth.is_server_admin(requester)), False
-        )
+        self.assertEqual(await self.auth.is_server_admin(requester), False)
         self.assertEqual(requester.device_id, DEVICE)
 
     def test_multiple_devices(self) -> None:
@@ -415,7 +407,7 @@ class MSC3861OAuthDelegation(HomeserverTestCase):
             'Bearer error="insufficient_scope", scope="urn:matrix:org.matrix.msc2967.client:api:*"',
         )
 
-    def test_active_guest_allowed(self) -> None:
+    async def test_active_guest_allowed(self) -> None:
         """The handler should return a requester with guest user rights and a device ID."""
 
         self.http_client.request = AsyncMock(
@@ -442,9 +434,7 @@ class MSC3861OAuthDelegation(HomeserverTestCase):
         self._assertParams()
         self.assertEqual(requester.user.to_string(), f"@{USERNAME}:{SERVER_NAME}")
         self.assertEqual(requester.is_guest, True)
-        self.assertEqual(
-            get_awaitable_result(self.auth.is_server_admin(requester)), False
-        )
+        self.assertEqual(await self.auth.is_server_admin(requester), False)
         self.assertEqual(requester.device_id, DEVICE)
 
     def test_unavailable_introspection_endpoint(self) -> None:
@@ -653,7 +643,7 @@ class MSC3861OAuthDelegation(HomeserverTestCase):
         self.expect_unrecognized("PUT", "/_relapse/admin/v1/users/foo/admin")
         self.expect_unrecognized("POST", "/_relapse/admin/v1/account_validity/validity")
 
-    def test_admin_token(self) -> None:
+    async def test_admin_token(self) -> None:
         """The handler should return a requester with admin rights when admin_token is used."""
         self.http_client.request = AsyncMock(
             return_value=FakeResponse.json(code=200, payload={"active": False}),
@@ -669,9 +659,7 @@ class MSC3861OAuthDelegation(HomeserverTestCase):
         )
         self.assertEqual(requester.is_guest, False)
         self.assertEqual(requester.device_id, None)
-        self.assertEqual(
-            get_awaitable_result(self.auth.is_server_admin(requester)), True
-        )
+        self.assertEqual(await self.auth.is_server_admin(requester), True)
 
         # There should be no call to the introspection endpoint
         self.http_client.request.assert_not_called()

--- a/tests/handlers/test_oidc.py
+++ b/tests/handlers/test_oidc.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-from collections.abc import Awaitable
 from contextlib import AbstractContextManager
 from typing import Any
 from unittest.mock import ANY, AsyncMock, Mock, patch
@@ -30,7 +29,7 @@ from relapse.util import Clock
 from relapse.util.macaroons import get_value_from_macaroon
 from relapse.util.stringutils import random_string
 
-from tests.test_utils import FakeResponse, get_awaitable_result
+from tests.test_utils import FakeResponse
 from tests.test_utils.oidc import FakeAuthorizationGrant, FakeOidcServer
 from tests.unittest import HomeserverTestCase, override_config
 
@@ -286,69 +285,69 @@ class OidcHandlerTestCase(HomeserverTestCase):
             self.get_failure(self.provider.load_jwks(force=True), RuntimeError)
 
     @override_config({"oidc_providers": [DEFAULT_CONFIG]})
-    def test_validate_config(self) -> None:
+    async def test_validate_config(self) -> None:
         """Provider metadatas are extensively validated."""
         h = self.provider
 
-        def force_load_metadata() -> Awaitable[None]:
-            async def force_load() -> "OpenIDProviderMetadata":
-                return await h.load_metadata(force=True)
-
-            return get_awaitable_result(force_load())
+        async def force_load_metadata() -> OpenIDProviderMetadata:
+            return await h.load_metadata(force=True)
 
         # Default test config does not throw
-        force_load_metadata()
+        await force_load_metadata()
 
         with self.metadata_edit({"issuer": None}):
-            self.assertRaisesRegex(ValueError, "issuer", force_load_metadata)
+            with self.assertRaisesRegex(ValueError, "issuer"):
+                await force_load_metadata()
 
         with self.metadata_edit({"issuer": "http://insecure/"}):
-            self.assertRaisesRegex(ValueError, "issuer", force_load_metadata)
+            with self.assertRaisesRegex(ValueError, "issuer"):
+                await force_load_metadata()
 
         with self.metadata_edit({"issuer": "https://invalid/?because=query"}):
-            self.assertRaisesRegex(ValueError, "issuer", force_load_metadata)
+            with self.assertRaisesRegex(ValueError, "issuer"):
+                await force_load_metadata()
 
         with self.metadata_edit({"authorization_endpoint": None}):
-            self.assertRaisesRegex(
-                ValueError, "authorization_endpoint", force_load_metadata
-            )
+            with self.assertRaisesRegex(ValueError, "authorization_endpoint"):
+                await force_load_metadata()
 
         with self.metadata_edit({"authorization_endpoint": "http://insecure/auth"}):
-            self.assertRaisesRegex(
-                ValueError, "authorization_endpoint", force_load_metadata
-            )
+            with self.assertRaisesRegex(ValueError, "authorization_endpoint"):
+                await force_load_metadata()
 
         with self.metadata_edit({"token_endpoint": None}):
-            self.assertRaisesRegex(ValueError, "token_endpoint", force_load_metadata)
+            with self.assertRaisesRegex(ValueError, "token_endpoint"):
+                await force_load_metadata()
 
         with self.metadata_edit({"token_endpoint": "http://insecure/token"}):
-            self.assertRaisesRegex(ValueError, "token_endpoint", force_load_metadata)
+            with self.assertRaisesRegex(ValueError, "token_endpoint"):
+                await force_load_metadata()
 
         with self.metadata_edit({"jwks_uri": None}):
-            self.assertRaisesRegex(ValueError, "jwks_uri", force_load_metadata)
+            with self.assertRaisesRegex(ValueError, "jwks_uri"):
+                await force_load_metadata()
 
         with self.metadata_edit({"jwks_uri": "http://insecure/jwks.json"}):
-            self.assertRaisesRegex(ValueError, "jwks_uri", force_load_metadata)
+            with self.assertRaisesRegex(ValueError, "jwks_uri"):
+                await force_load_metadata()
 
         with self.metadata_edit({"response_types_supported": ["id_token"]}):
-            self.assertRaisesRegex(
-                ValueError, "response_types_supported", force_load_metadata
-            )
+            with self.assertRaisesRegex(ValueError, "response_types_supported"):
+                await force_load_metadata()
 
         with self.metadata_edit(
             {"token_endpoint_auth_methods_supported": ["client_secret_basic"]}
         ):
             # should not throw, as client_secret_basic is the default auth method
-            force_load_metadata()
+            await force_load_metadata()
 
         with self.metadata_edit(
             {"token_endpoint_auth_methods_supported": ["client_secret_post"]}
         ):
-            self.assertRaisesRegex(
-                ValueError,
-                "token_endpoint_auth_methods_supported",
-                force_load_metadata,
-            )
+            with self.assertRaisesRegex(
+                ValueError, "token_endpoint_auth_methods_supported"
+            ):
+                await force_load_metadata()
 
         # Tests for configs that require the userinfo endpoint
         self.assertFalse(h._uses_userinfo)
@@ -362,20 +361,21 @@ class OidcHandlerTestCase(HomeserverTestCase):
         h._scopes = []
         self.assertTrue(h._uses_userinfo)
         with self.metadata_edit({"userinfo_endpoint": None}):
-            self.assertRaisesRegex(ValueError, "userinfo_endpoint", force_load_metadata)
+            with self.assertRaisesRegex(ValueError, "userinfo_endpoint"):
+                await force_load_metadata()
 
         with self.metadata_edit({"jwks_uri": None}):
             # Shouldn't raise with a valid userinfo, even without jwks
-            force_load_metadata()
+            await force_load_metadata()
 
     @override_config(
         {"oidc_providers": [{**DEFAULT_CONFIG, "skip_verification": True}]}
     )
-    def test_skip_verification(self) -> None:
+    async def test_skip_verification(self) -> None:
         """Provider metadata validation can be disabled by config."""
         with self.metadata_edit({"issuer": "http://insecure"}):
             # This should not throw
-            get_awaitable_result(self.provider.load_metadata())
+            await self.provider.load_metadata()
 
     @override_config({"oidc_providers": [DEFAULT_CONFIG]})
     def test_redirect_request(self) -> None:

--- a/tests/http/federation/test_matrix_federation_agent.py
+++ b/tests/http/federation/test_matrix_federation_agent.py
@@ -273,19 +273,19 @@ class MatrixFederationAgentTests(unittest.TestCase):
             _well_known_resolver=self.well_known_resolver,
         )
 
-    def test_get(self) -> None:
+    async def test_get(self) -> None:
         """happy-path test of a GET request with an explicit port"""
-        self._do_get()
+        await self._do_get()
 
     @patch.dict(
         os.environ,
         {"https_proxy": "proxy.com", "no_proxy": "testserv"},
     )
-    def test_get_bypass_proxy(self) -> None:
+    async def test_get_bypass_proxy(self) -> None:
         """test of a GET request with an explicit port and bypass proxy"""
-        self._do_get()
+        await self._do_get()
 
-    def _do_get(self) -> None:
+    async def _do_get(self) -> None:
         """test of a GET request with an explicit port"""
         self.agent = self._make_agent()
 
@@ -327,7 +327,7 @@ class MatrixFederationAgentTests(unittest.TestCase):
 
         self.reactor.pump((0.1,))
 
-        response = self.successResultOf(test_d)
+        response = await test_d
 
         # that should give us a Response object
         self.assertEqual(response.code, 200)
@@ -339,44 +339,48 @@ class MatrixFederationAgentTests(unittest.TestCase):
         self.reactor.pump((0.1,))
 
         # check it can be read
-        json = self.successResultOf(treq.json_content(response))
+        json = await treq.json_content(response)
         self.assertEqual(json, {"a": 1})
 
     @patch.dict(
         os.environ, {"https_proxy": "http://proxy.com", "no_proxy": "unused.com"}
     )
-    def test_get_via_http_proxy(self) -> None:
+    async def test_get_via_http_proxy(self) -> None:
         """test for federation request through a http proxy"""
-        self._do_get_via_proxy(expect_proxy_ssl=False, expected_auth_credentials=None)
+        await self._do_get_via_proxy(
+            expect_proxy_ssl=False, expected_auth_credentials=None
+        )
 
     @patch.dict(
         os.environ,
         {"https_proxy": "http://user:pass@proxy.com", "no_proxy": "unused.com"},
     )
-    def test_get_via_http_proxy_with_auth(self) -> None:
+    async def test_get_via_http_proxy_with_auth(self) -> None:
         """test for federation request through a http proxy with authentication"""
-        self._do_get_via_proxy(
+        await self._do_get_via_proxy(
             expect_proxy_ssl=False, expected_auth_credentials=b"user:pass"
         )
 
     @patch.dict(
         os.environ, {"https_proxy": "https://proxy.com", "no_proxy": "unused.com"}
     )
-    def test_get_via_https_proxy(self) -> None:
+    async def test_get_via_https_proxy(self) -> None:
         """test for federation request through a https proxy"""
-        self._do_get_via_proxy(expect_proxy_ssl=True, expected_auth_credentials=None)
+        await self._do_get_via_proxy(
+            expect_proxy_ssl=True, expected_auth_credentials=None
+        )
 
     @patch.dict(
         os.environ,
         {"https_proxy": "https://user:pass@proxy.com", "no_proxy": "unused.com"},
     )
-    def test_get_via_https_proxy_with_auth(self) -> None:
+    async def test_get_via_https_proxy_with_auth(self) -> None:
         """test for federation request through a https proxy with authentication"""
-        self._do_get_via_proxy(
+        await self._do_get_via_proxy(
             expect_proxy_ssl=True, expected_auth_credentials=b"user:pass"
         )
 
-    def _do_get_via_proxy(
+    async def _do_get_via_proxy(
         self,
         expect_proxy_ssl: bool = False,
         expected_auth_credentials: bytes | None = None,
@@ -514,7 +518,7 @@ class MatrixFederationAgentTests(unittest.TestCase):
 
         self.reactor.pump((0.1,))
 
-        response = self.successResultOf(test_d)
+        response = await test_d
 
         # that should give us a Response object
         self.assertEqual(response.code, 200)
@@ -526,10 +530,10 @@ class MatrixFederationAgentTests(unittest.TestCase):
         self.reactor.pump((0.1,))
 
         # check it can be read
-        json = self.successResultOf(treq.json_content(response))
+        json = await treq.json_content(response)
         self.assertEqual(json, {"a": 1})
 
-    def test_get_ip_address(self) -> None:
+    async def test_get_ip_address(self) -> None:
         """
         Test the behaviour when the server name contains an explicit IP (with no port)
         """
@@ -562,9 +566,9 @@ class MatrixFederationAgentTests(unittest.TestCase):
         # finish the request
         request.finish()
         self.reactor.pump((0.1,))
-        self.successResultOf(test_d)
+        await test_d
 
-    def test_get_ipv6_address(self) -> None:
+    async def test_get_ipv6_address(self) -> None:
         """
         Test the behaviour when the server name contains an explicit IPv6 address
         (with no port)
@@ -598,9 +602,9 @@ class MatrixFederationAgentTests(unittest.TestCase):
         # finish the request
         request.finish()
         self.reactor.pump((0.1,))
-        self.successResultOf(test_d)
+        await test_d
 
-    def test_get_ipv6_address_with_port(self) -> None:
+    async def test_get_ipv6_address_with_port(self) -> None:
         """
         Test the behaviour when the server name contains an explicit IPv6 address
         (with explicit port)
@@ -634,9 +638,9 @@ class MatrixFederationAgentTests(unittest.TestCase):
         # finish the request
         request.finish()
         self.reactor.pump((0.1,))
-        self.successResultOf(test_d)
+        await test_d
 
-    def test_get_hostname_bad_cert(self) -> None:
+    async def test_get_hostname_bad_cert(self) -> None:
         """
         Test the behaviour when the certificate on the server doesn't match the hostname
         """
@@ -685,11 +689,12 @@ class MatrixFederationAgentTests(unittest.TestCase):
         self.assertEqual(len(http_server.requests), 0)
 
         # ... and the request should have failed
-        e = self.failureResultOf(test_d, ResponseNeverReceived)
-        failure_reason = e.value.reasons[0]
+        with self.assertRaises(ResponseNeverReceived) as e:
+            await test_d
+        failure_reason = e.exception.reasons[0]
         self.assertIsInstance(failure_reason.value, VerificationError)
 
-    def test_get_ip_address_bad_cert(self) -> None:
+    async def test_get_ip_address_bad_cert(self) -> None:
         """
         Test the behaviour when the server name contains an explicit IP, but
         the server cert doesn't cover it
@@ -718,11 +723,12 @@ class MatrixFederationAgentTests(unittest.TestCase):
         self.assertEqual(len(http_server.requests), 0)
 
         # ... and the request should have failed
-        e = self.failureResultOf(test_d, ResponseNeverReceived)
-        failure_reason = e.value.reasons[0]
+        with self.assertRaises(ResponseNeverReceived) as e:
+            await test_d
+        failure_reason = e.exception.reasons[0]
         self.assertIsInstance(failure_reason.value, VerificationError)
 
-    def test_get_no_srv_no_well_known(self) -> None:
+    async def test_get_no_srv_no_well_known(self) -> None:
         """
         Test the behaviour when the server name has no port, no SRV, and no well-known
         """
@@ -776,9 +782,9 @@ class MatrixFederationAgentTests(unittest.TestCase):
         # finish the request
         request.finish()
         self.reactor.pump((0.1,))
-        self.successResultOf(test_d)
+        await test_d
 
-    def test_get_well_known(self) -> None:
+    async def test_get_well_known(self) -> None:
         """Test the behaviour when the .well-known delegates elsewhere"""
         self.agent = self._make_agent()
 
@@ -834,7 +840,7 @@ class MatrixFederationAgentTests(unittest.TestCase):
         # finish the request
         request.finish()
         self.reactor.pump((0.1,))
-        self.successResultOf(test_d)
+        await test_d
 
         self.assertEqual(self.well_known_cache[b"testserv"], b"target-server")
 
@@ -843,7 +849,7 @@ class MatrixFederationAgentTests(unittest.TestCase):
         self.well_known_cache.expire()
         self.assertNotIn(b"testserv", self.well_known_cache)
 
-    def test_get_well_known_redirect(self) -> None:
+    async def test_get_well_known_redirect(self) -> None:
         """Test the behaviour when the server name has no port and no SRV record, but
         the .well-known has a 300 redirect
         """
@@ -927,7 +933,7 @@ class MatrixFederationAgentTests(unittest.TestCase):
         # finish the request
         request.finish()
         self.reactor.pump((0.1,))
-        self.successResultOf(test_d)
+        await test_d
 
         self.assertEqual(self.well_known_cache[b"testserv"], b"target-server")
 
@@ -936,7 +942,7 @@ class MatrixFederationAgentTests(unittest.TestCase):
         self.well_known_cache.expire()
         self.assertNotIn(b"testserv", self.well_known_cache)
 
-    def test_get_invalid_well_known(self) -> None:
+    async def test_get_invalid_well_known(self) -> None:
         """
         Test the behaviour when the server name has an *invalid* well-known (and no SRV)
         """
@@ -987,7 +993,7 @@ class MatrixFederationAgentTests(unittest.TestCase):
         # finish the request
         request.finish()
         self.reactor.pump((0.1,))
-        self.successResultOf(test_d)
+        await test_d
 
     def test_get_well_known_unsigned_cert(self) -> None:
         """Test the behaviour when the .well-known server presents a cert
@@ -1043,7 +1049,7 @@ class MatrixFederationAgentTests(unittest.TestCase):
             [call(b"_matrix-fed._tcp.testserv"), call(b"_matrix._tcp.testserv")]
         )
 
-    def test_get_hostname_srv(self) -> None:
+    async def test_get_hostname_srv(self) -> None:
         """
         Test the behaviour when there is a single SRV record for _matrix-fed.
         """
@@ -1083,9 +1089,9 @@ class MatrixFederationAgentTests(unittest.TestCase):
         # finish the request
         request.finish()
         self.reactor.pump((0.1,))
-        self.successResultOf(test_d)
+        await test_d
 
-    def test_get_hostname_srv_legacy(self) -> None:
+    async def test_get_hostname_srv_legacy(self) -> None:
         """
         Test the behaviour when there is a single SRV record for _matrix.
         """
@@ -1127,9 +1133,9 @@ class MatrixFederationAgentTests(unittest.TestCase):
         # finish the request
         request.finish()
         self.reactor.pump((0.1,))
-        self.successResultOf(test_d)
+        await test_d
 
-    def test_get_well_known_srv(self) -> None:
+    async def test_get_well_known_srv(self) -> None:
         """Test the behaviour when the .well-known redirects to a place where there
         is a _matrix-fed SRV record.
         """
@@ -1187,9 +1193,9 @@ class MatrixFederationAgentTests(unittest.TestCase):
         # finish the request
         request.finish()
         self.reactor.pump((0.1,))
-        self.successResultOf(test_d)
+        await test_d
 
-    def test_get_well_known_srv_legacy(self) -> None:
+    async def test_get_well_known_srv_legacy(self) -> None:
         """Test the behaviour when the .well-known redirects to a place where there
         is a _matrix SRV record.
         """
@@ -1252,9 +1258,9 @@ class MatrixFederationAgentTests(unittest.TestCase):
         # finish the request
         request.finish()
         self.reactor.pump((0.1,))
-        self.successResultOf(test_d)
+        await test_d
 
-    def test_idna_servername(self) -> None:
+    async def test_idna_servername(self) -> None:
         """test the behaviour when the server name has idna chars in"""
         self.agent = self._make_agent()
 
@@ -1319,9 +1325,9 @@ class MatrixFederationAgentTests(unittest.TestCase):
         # finish the request
         request.finish()
         self.reactor.pump((0.1,))
-        self.successResultOf(test_d)
+        await test_d
 
-    def test_idna_srv_target(self) -> None:
+    async def test_idna_srv_target(self) -> None:
         """test the behaviour when the target of a _matrix-fed SRV record has idna chars"""
         self.agent = self._make_agent()
 
@@ -1364,9 +1370,9 @@ class MatrixFederationAgentTests(unittest.TestCase):
         # finish the request
         request.finish()
         self.reactor.pump((0.1,))
-        self.successResultOf(test_d)
+        await test_d
 
-    def test_idna_srv_target_legacy(self) -> None:
+    async def test_idna_srv_target_legacy(self) -> None:
         """test the behaviour when the target of a _matrix SRV record has idna chars"""
         self.agent = self._make_agent()
 
@@ -1414,9 +1420,9 @@ class MatrixFederationAgentTests(unittest.TestCase):
         # finish the request
         request.finish()
         self.reactor.pump((0.1,))
-        self.successResultOf(test_d)
+        await test_d
 
-    def test_well_known_cache(self) -> None:
+    async def test_well_known_cache(self) -> None:
         self.reactor.lookups["testserv"] = "1.2.3.4"
 
         fetch_d = defer.ensureDeferred(
@@ -1437,7 +1443,7 @@ class MatrixFederationAgentTests(unittest.TestCase):
             content=b'{ "m.server": "target-server" }',
         )
 
-        r = self.successResultOf(fetch_d)
+        r = await fetch_d
         self.assertEqual(r.delegated_server, b"target-server")
 
         # close the tcp connection
@@ -1447,7 +1453,7 @@ class MatrixFederationAgentTests(unittest.TestCase):
         fetch_d = defer.ensureDeferred(
             self.well_known_resolver.get_well_known(b"testserv")
         )
-        r = self.successResultOf(fetch_d)
+        r = await fetch_d
         self.assertEqual(r.delegated_server, b"target-server")
 
         # expire the cache
@@ -1469,10 +1475,10 @@ class MatrixFederationAgentTests(unittest.TestCase):
             content=b'{ "m.server": "other-server" }',
         )
 
-        r = self.successResultOf(fetch_d)
+        r = await fetch_d
         self.assertEqual(r.delegated_server, b"other-server")
 
-    def test_well_known_cache_with_temp_failure(self) -> None:
+    async def test_well_known_cache_with_temp_failure(self) -> None:
         """Test that we refetch well-known before the cache expires, and that
         it ignores transient errors.
         """
@@ -1497,7 +1503,7 @@ class MatrixFederationAgentTests(unittest.TestCase):
             content=b'{ "m.server": "target-server" }',
         )
 
-        r = self.successResultOf(fetch_d)
+        r = await fetch_d
         self.assertEqual(r.delegated_server, b"target-server")
 
         # close the tcp connection
@@ -1532,7 +1538,7 @@ class MatrixFederationAgentTests(unittest.TestCase):
         self.assertGreater(attempts, 1)
 
         # Resolver should return cached value, despite the lookup failing.
-        r = self.successResultOf(fetch_d)
+        r = await fetch_d
         self.assertEqual(r.delegated_server, b"target-server")
 
         # Expire both caches and repeat the request
@@ -1548,10 +1554,10 @@ class MatrixFederationAgentTests(unittest.TestCase):
         client_factory.clientConnectionFailed(None, Exception("nope"))
         self.reactor.pump((0.4,))
 
-        r = self.successResultOf(fetch_d)
+        r = await fetch_d
         self.assertEqual(r.delegated_server, None)
 
-    def test_well_known_too_large(self) -> None:
+    async def test_well_known_too_large(self) -> None:
         """A well-known query that returns a result which is too large should be rejected."""
         self.reactor.lookups["testserv"] = "1.2.3.4"
 
@@ -1574,10 +1580,10 @@ class MatrixFederationAgentTests(unittest.TestCase):
         )
 
         # The result is successful, but disabled delegation.
-        r = self.successResultOf(fetch_d)
+        r = await fetch_d
         self.assertIsNone(r.delegated_server)
 
-    def test_srv_fallbacks(self) -> None:
+    async def test_srv_fallbacks(self) -> None:
         """Test that other SRV results are tried if the first one fails for _matrix-fed SRV."""
         self.agent = self._make_agent()
 
@@ -1631,9 +1637,9 @@ class MatrixFederationAgentTests(unittest.TestCase):
         # finish the request
         request.finish()
         self.reactor.pump((0.1,))
-        self.successResultOf(test_d)
+        await test_d
 
-    def test_srv_fallbacks_legacy(self) -> None:
+    async def test_srv_fallbacks_legacy(self) -> None:
         """Test that other SRV results are tried if the first one fails for _matrix SRV."""
         self.agent = self._make_agent()
 
@@ -1691,7 +1697,7 @@ class MatrixFederationAgentTests(unittest.TestCase):
         # finish the request
         request.finish()
         self.reactor.pump((0.1,))
-        self.successResultOf(test_d)
+        await test_d
 
     def test_srv_no_fallback_to_legacy(self) -> None:
         """Test that _matrix SRV results are not tried if the _matrix-fed one fails."""

--- a/tests/http/federation/test_srv_resolver.py
+++ b/tests/http/federation/test_srv_resolver.py
@@ -28,7 +28,7 @@ from tests.utils import MockClock
 
 
 class SrvResolverTestCase(unittest.TestCase):
-    def test_resolve(self) -> None:
+    async def test_resolve(self) -> None:
         dns_client_mock = Mock()
 
         service_name = b"test_service.example.com"
@@ -62,7 +62,7 @@ class SrvResolverTestCase(unittest.TestCase):
 
         result_deferred.callback(([answer_srv], None, None))
 
-        servers = self.successResultOf(test_d)
+        servers = await test_d
 
         self.assertEqual(len(servers), 1)
         self.assertEqual(servers, cache[service_name])
@@ -173,7 +173,7 @@ class SrvResolverTestCase(unittest.TestCase):
 
         self.failureResultOf(resolve_d, ConnectError)
 
-    def test_non_srv_answer(self) -> None:
+    async def test_non_srv_answer(self) -> None:
         """
         test the behaviour when the dns server gives us a spurious non-SRV response
         """
@@ -199,7 +199,7 @@ class SrvResolverTestCase(unittest.TestCase):
             )
         )
 
-        servers = self.successResultOf(resolve_d)
+        servers = await resolve_d
 
         self.assertEqual(len(servers), 1)
         self.assertEqual(servers, cache[service_name])

--- a/tests/http/federation/test_srv_resolver.py
+++ b/tests/http/federation/test_srv_resolver.py
@@ -147,7 +147,7 @@ class SrvResolverTestCase(unittest.TestCase):
         self.assertEqual(len(servers), 0)
         self.assertEqual(len(cache), 0)
 
-    def test_disabled_service(self) -> None:
+    async def test_disabled_service(self) -> None:
         """
         test the behaviour when there is a single record which is ".".
         """
@@ -159,7 +159,6 @@ class SrvResolverTestCase(unittest.TestCase):
         cache: dict[bytes, list[Server]] = {}
         resolver = SrvResolver(dns_client=dns_client_mock, cache=cache)
 
-        # Old versions of Twisted don't have an ensureDeferred in failureResultOf.
         resolve_d = resolver.resolve_service(service_name)
 
         # returning a single "." should make the lookup fail with a ConenctError
@@ -171,7 +170,8 @@ class SrvResolverTestCase(unittest.TestCase):
             )
         )
 
-        self.failureResultOf(resolve_d, ConnectError)
+        with self.assertRaises(ConnectError):
+            await resolve_d
 
     async def test_non_srv_answer(self) -> None:
         """
@@ -185,7 +185,6 @@ class SrvResolverTestCase(unittest.TestCase):
         cache: dict[bytes, list[Server]] = {}
         resolver = SrvResolver(dns_client=dns_client_mock, cache=cache)
 
-        # Old versions of Twisted don't have an ensureDeferred in successResultOf.
         resolve_d = resolver.resolve_service(service_name)
 
         lookup_deferred.callback(

--- a/tests/http/federation/test_srv_resolver.py
+++ b/tests/http/federation/test_srv_resolver.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from collections.abc import Generator
 from typing import cast
 from unittest.mock import Mock
 
@@ -45,19 +44,18 @@ class SrvResolverTestCase(unittest.TestCase):
         cache: dict[bytes, list[Server]] = {}
         resolver = SrvResolver(dns_client=dns_client_mock, cache=cache)
 
-        @defer.inlineCallbacks
-        def do_lookup() -> Generator["Deferred[object]", object, list[Server]]:
+        async def do_lookup() -> list[Server]:
             with LoggingContext("one") as ctx:
                 resolve_d = resolver.resolve_service(service_name)
                 result: list[Server]
-                result = yield defer.ensureDeferred(resolve_d)  # type: ignore[assignment]
+                result = await resolve_d
 
                 # should have restored our context
                 self.assertIs(current_context(), ctx)
 
                 return result
 
-        test_d = do_lookup()
+        test_d = defer.ensureDeferred(do_lookup())
         self.assertNoResult(test_d)
 
         dns_client_mock.lookupService.assert_called_once_with(service_name)
@@ -70,10 +68,9 @@ class SrvResolverTestCase(unittest.TestCase):
         self.assertEqual(servers, cache[service_name])
         self.assertEqual(servers[0].host, host_name)
 
-    @defer.inlineCallbacks
-    def test_from_cache_expired_and_dns_fail(
+    async def test_from_cache_expired_and_dns_fail(
         self,
-    ) -> Generator["Deferred[object]", object, None]:
+    ) -> None:
         dns_client_mock = Mock()
         dns_client_mock.lookupService.return_value = defer.fail(error.DNSServerError())
 
@@ -88,15 +85,14 @@ class SrvResolverTestCase(unittest.TestCase):
         resolver = SrvResolver(dns_client=dns_client_mock, cache=cache)
 
         servers: list[Server]
-        servers = yield defer.ensureDeferred(resolver.resolve_service(service_name))  # type: ignore[assignment]
+        servers = await resolver.resolve_service(service_name)
 
         dns_client_mock.lookupService.assert_called_once_with(service_name)
 
         self.assertEqual(len(servers), 1)
         self.assertEqual(servers, cache[service_name])
 
-    @defer.inlineCallbacks
-    def test_from_cache(self) -> Generator["Deferred[object]", object, None]:
+    async def test_from_cache(self) -> None:
         clock = MockClock()
 
         dns_client_mock = Mock(spec_set=["lookupService"])
@@ -115,15 +111,14 @@ class SrvResolverTestCase(unittest.TestCase):
         )
 
         servers: list[Server]
-        servers = yield defer.ensureDeferred(resolver.resolve_service(service_name))  # type: ignore[assignment]
+        servers = await resolver.resolve_service(service_name)
 
         self.assertFalse(dns_client_mock.lookupService.called)
 
         self.assertEqual(len(servers), 1)
         self.assertEqual(servers, cache[service_name])
 
-    @defer.inlineCallbacks
-    def test_empty_cache(self) -> Generator["Deferred[object]", object, None]:
+    async def test_empty_cache(self) -> None:
         dns_client_mock = Mock()
 
         dns_client_mock.lookupService.return_value = defer.fail(error.DNSServerError())
@@ -134,10 +129,9 @@ class SrvResolverTestCase(unittest.TestCase):
         resolver = SrvResolver(dns_client=dns_client_mock, cache=cache)
 
         with self.assertRaises(error.DNSServerError):
-            yield defer.ensureDeferred(resolver.resolve_service(service_name))
+            await resolver.resolve_service(service_name)
 
-    @defer.inlineCallbacks
-    def test_name_error(self) -> Generator["Deferred[object]", object, None]:
+    async def test_name_error(self) -> None:
         dns_client_mock = Mock()
 
         dns_client_mock.lookupService.return_value = defer.fail(error.DNSNameError())
@@ -148,7 +142,7 @@ class SrvResolverTestCase(unittest.TestCase):
         resolver = SrvResolver(dns_client=dns_client_mock, cache=cache)
 
         servers: list[Server]
-        servers = yield defer.ensureDeferred(resolver.resolve_service(service_name))  # type: ignore[assignment]
+        servers = await resolver.resolve_service(service_name)
 
         self.assertEqual(len(servers), 0)
         self.assertEqual(len(cache), 0)
@@ -166,7 +160,7 @@ class SrvResolverTestCase(unittest.TestCase):
         resolver = SrvResolver(dns_client=dns_client_mock, cache=cache)
 
         # Old versions of Twisted don't have an ensureDeferred in failureResultOf.
-        resolve_d = defer.ensureDeferred(resolver.resolve_service(service_name))
+        resolve_d = resolver.resolve_service(service_name)
 
         # returning a single "." should make the lookup fail with a ConenctError
         lookup_deferred.callback(
@@ -192,7 +186,7 @@ class SrvResolverTestCase(unittest.TestCase):
         resolver = SrvResolver(dns_client=dns_client_mock, cache=cache)
 
         # Old versions of Twisted don't have an ensureDeferred in successResultOf.
-        resolve_d = defer.ensureDeferred(resolver.resolve_service(service_name))
+        resolve_d = resolver.resolve_service(service_name)
 
         lookup_deferred.callback(
             (

--- a/tests/http/test_client.py
+++ b/tests/http/test_client.py
@@ -159,7 +159,7 @@ class BlocklistingAgentTest(TestCase):
         self.ip_allowlist = IPSet([self.allowed_ip.decode()])
         self.ip_blocklist = IPSet(["5.0.0.0/8"])
 
-    def test_reactor(self) -> None:
+    async def test_reactor(self) -> None:
         """Apply the blocklisting reactor and ensure it properly blocks connections to particular domains and IPs."""
         agent = Agent(
             BlocklistingReactorWrapper(
@@ -171,9 +171,8 @@ class BlocklistingAgentTest(TestCase):
 
         # The unsafe domains and IPs should be rejected.
         for domain in (self.unsafe_domain, self.unsafe_ip):
-            self.failureResultOf(
-                agent.request(b"GET", b"http://" + domain), DNSLookupError
-            )
+            with self.assertRaises(DNSLookupError):
+                await agent.request(b"GET", b"http://" + domain)
 
         # The safe domains IPs should be accepted.
         for domain in (
@@ -202,10 +201,10 @@ class BlocklistingAgentTest(TestCase):
                 b"HTTP/1.0 200 OK\r\nContent-Length: 0\r\nContent-Type: text/html\r\n\r\n"
             )
 
-            response = self.successResultOf(d)
+            response = await d
             self.assertEqual(response.code, 200)
 
-    def test_agent(self) -> None:
+    async def test_agent(self) -> None:
         """Apply the blocklisting agent and ensure it properly blocks connections to particular IPs."""
         agent = BlocklistingAgentWrapper(
             Agent(self.reactor),
@@ -214,9 +213,8 @@ class BlocklistingAgentTest(TestCase):
         )
 
         # The unsafe IPs should be rejected.
-        self.failureResultOf(
-            agent.request(b"GET", b"http://" + self.unsafe_ip), RelapseError
-        )
+        with self.assertRaises(RelapseError):
+            await agent.request(b"GET", b"http://" + self.unsafe_ip)
 
         # The safe and unsafe domains and safe IPs should be accepted.
         for domain in (
@@ -246,5 +244,5 @@ class BlocklistingAgentTest(TestCase):
                 b"HTTP/1.0 200 OK\r\nContent-Length: 0\r\nContent-Type: text/html\r\n\r\n"
             )
 
-            response = self.successResultOf(d)
+            response = await d
             self.assertEqual(response.code, 200)

--- a/tests/http/test_matrixfederationclient.py
+++ b/tests/http/test_matrixfederationclient.py
@@ -65,7 +65,7 @@ class FederationClientTests(HomeserverTestCase):
         self.cl = MatrixFederationHttpClient(self.hs, None)
         self.reactor.lookups["testserv"] = "1.2.3.4"
 
-    def test_client_get(self) -> None:
+    async def test_client_get(self) -> None:
         """
         happy-path test of a GET request
         """
@@ -128,12 +128,12 @@ class FederationClientTests(HomeserverTestCase):
 
         self.pump()
 
-        res = self.successResultOf(test_d)
+        res = await test_d
 
         # check the response is as expected
         self.assertEqual(res, {"a": 1})
 
-    def test_dns_error(self) -> None:
+    async def test_dns_error(self) -> None:
         """
         If the DNS lookup returns an error, it will bubble up.
         """
@@ -142,11 +142,11 @@ class FederationClientTests(HomeserverTestCase):
         )
         self.pump()
 
-        f = self.failureResultOf(d)
-        self.assertIsInstance(f.value, RequestSendFailed)
-        self.assertIsInstance(f.value.inner_exception, DNSLookupError)
+        with self.assertRaises(RequestSendFailed) as e:
+            await d
+        self.assertIsInstance(e.exception.inner_exception, DNSLookupError)
 
-    def test_client_connection_refused(self) -> None:
+    async def test_client_connection_refused(self) -> None:
         d = defer.ensureDeferred(
             self.cl.get_json("testserv:8008", "foo/bar", timeout=10000)
         )
@@ -165,12 +165,12 @@ class FederationClientTests(HomeserverTestCase):
         factory.clientConnectionFailed(None, e)
         self.pump(0.5)
 
-        f = self.failureResultOf(d)
+        with self.assertRaises(RequestSendFailed) as exc:
+            await d
 
-        self.assertIsInstance(f.value, RequestSendFailed)
-        self.assertIs(f.value.inner_exception, e)
+        self.assertIs(exc.exception.inner_exception, e)
 
-    def test_client_never_connect(self) -> None:
+    async def test_client_never_connect(self) -> None:
         """
         If the HTTP request is not connected and is timed out, it'll give a
         ConnectingCancelledError or TimeoutError.
@@ -195,14 +195,14 @@ class FederationClientTests(HomeserverTestCase):
 
         # Push by enough to time it out
         self.reactor.advance(10.5)
-        f = self.failureResultOf(d)
+        with self.assertRaises(RequestSendFailed) as e:
+            await d
 
-        self.assertIsInstance(f.value, RequestSendFailed)
         self.assertIsInstance(
-            f.value.inner_exception, (ConnectingCancelledError, TimeoutError)
+            e.exception.inner_exception, (ConnectingCancelledError, TimeoutError)
         )
 
-    def test_client_connect_no_response(self) -> None:
+    async def test_client_connect_no_response(self) -> None:
         """
         If the HTTP request is connected, but gets no response before being
         timed out, it'll give a ResponseNeverReceived.
@@ -231,12 +231,12 @@ class FederationClientTests(HomeserverTestCase):
 
         # Push by enough to time it out
         self.reactor.advance(10.5)
-        f = self.failureResultOf(d)
+        with self.assertRaises(RequestSendFailed) as e:
+            await d
 
-        self.assertIsInstance(f.value, RequestSendFailed)
-        self.assertIsInstance(f.value.inner_exception, ResponseNeverReceived)
+        self.assertIsInstance(e.exception.inner_exception, ResponseNeverReceived)
 
-    def test_client_ip_range_blocklist(self) -> None:
+    async def test_client_ip_range_blocklist(self) -> None:
         """Ensure that Relapse does not try to connect to blocked IPs"""
 
         # Set up the ip_range blocklist
@@ -260,9 +260,9 @@ class FederationClientTests(HomeserverTestCase):
         clients = self.reactor.tcpClients
         self.assertEqual(len(clients), 0)
 
-        f = self.failureResultOf(d)
-        self.assertIsInstance(f.value, RequestSendFailed)
-        self.assertIsInstance(f.value.inner_exception, DNSLookupError)
+        with self.assertRaises(RequestSendFailed) as e:
+            await d
+        self.assertIsInstance(e.exception.inner_exception, DNSLookupError)
 
         # Try making a POST request to a blocked IPv6 address
         # -------------------------------------------------------
@@ -282,8 +282,9 @@ class FederationClientTests(HomeserverTestCase):
         self.assertEqual(len(clients), 0)
 
         # Check that it was due to a blocked DNS lookup
-        f = self.failureResultOf(d, RequestSendFailed)
-        self.assertIsInstance(f.value.inner_exception, DNSLookupError)
+        with self.assertRaises(RequestSendFailed) as e:
+            await d
+        self.assertIsInstance(e.exception.inner_exception, DNSLookupError)
 
         # Try making a GET request to an allowed IPv4 address
         # ----------------------------------------------------------
@@ -301,10 +302,11 @@ class FederationClientTests(HomeserverTestCase):
         self.assertNotEqual(len(clients), 0)
 
         # Connection will still fail as this IP address does not resolve to anything
-        f = self.failureResultOf(d, RequestSendFailed)
-        self.assertIsInstance(f.value.inner_exception, ConnectingCancelledError)
+        with self.assertRaises(RequestSendFailed) as e:
+            await d
+        self.assertIsInstance(e.exception.inner_exception, ConnectingCancelledError)
 
-    def test_client_gets_headers(self) -> None:
+    async def test_client_gets_headers(self) -> None:
         """
         Once the client gets the headers, _request returns successfully.
         """
@@ -327,11 +329,11 @@ class FederationClientTests(HomeserverTestCase):
         client.dataReceived(b"HTTP/1.1 200 OK\r\nServer: Fake\r\n\r\n")
 
         # We should get a successful response
-        r = self.successResultOf(d)
+        r = await d
         self.assertEqual(r.code, 200)
 
     @parameterized.expand(["get_json", "post_json", "delete_json", "put_json"])
-    def test_timeout_reading_body(self, method_name: str) -> None:
+    async def test_timeout_reading_body(self, method_name: str) -> None:
         """
         If the HTTP request is connected, but gets no response before being
         timed out, it'll give a RequestSendFailed with can_retry.
@@ -356,13 +358,13 @@ class FederationClientTests(HomeserverTestCase):
 
         # Push by enough to time it out
         self.reactor.advance(10.5)
-        f = self.failureResultOf(d)
+        with self.assertRaises(RequestSendFailed) as e:
+            await d
 
-        self.assertIsInstance(f.value, RequestSendFailed)
-        self.assertTrue(f.value.can_retry)
-        self.assertIsInstance(f.value.inner_exception, defer.TimeoutError)
+        self.assertTrue(e.exception.can_retry)
+        self.assertIsInstance(e.exception.inner_exception, defer.TimeoutError)
 
-    def test_client_requires_trailing_slashes(self) -> None:
+    async def test_client_requires_trailing_slashes(self) -> None:
         """
         If a connection is made to a client but the client rejects it due to
         requiring a trailing slash. We need to retry the request with a
@@ -414,10 +416,10 @@ class FederationClientTests(HomeserverTestCase):
         )
 
         # We should get a successful response
-        r = self.successResultOf(d)
+        r = await d
         self.assertEqual(r, {})
 
-    def test_client_does_not_retry_on_400_plus(self) -> None:
+    async def test_client_does_not_retry_on_400_plus(self) -> None:
         """
         Another test for trailing slashes but now test that we don't retry on
         trailing slashes on a non-400/M_UNRECOGNIZED response.
@@ -460,7 +462,8 @@ class FederationClientTests(HomeserverTestCase):
         self.assertEqual(conn.value(), b"")
 
         # We should get a 404 failure response
-        self.failureResultOf(d)
+        with self.assertRaises(HttpResponseException):
+            await d
 
     def test_client_sends_body(self) -> None:
         defer.ensureDeferred(
@@ -486,7 +489,7 @@ class FederationClientTests(HomeserverTestCase):
         content = request.content.read()
         self.assertEqual(content, b'{"a":"b"}')
 
-    def test_closes_connection(self) -> None:
+    async def test_closes_connection(self) -> None:
         """Check that the client closes unused HTTP connections"""
         d = defer.ensureDeferred(self.cl.get_json("testserv:8008", "foo/bar"))
 
@@ -515,7 +518,7 @@ class FederationClientTests(HomeserverTestCase):
         )
 
         # We should get a successful response
-        r = self.successResultOf(d)
+        r = await d
         self.assertEqual(r, {})
 
         self.assertFalse(conn.disconnecting)
@@ -526,7 +529,7 @@ class FederationClientTests(HomeserverTestCase):
         self.assertTrue(conn.disconnecting)
 
     @parameterized.expand([(b"",), (b"foo",), (b'{"a": Infinity}',)])
-    def test_json_error(self, return_value: bytes) -> None:
+    async def test_json_error(self, return_value: bytes) -> None:
         """
         Test what happens if invalid JSON is returned from the remote endpoint.
         """
@@ -569,10 +572,10 @@ class FederationClientTests(HomeserverTestCase):
 
         self.pump()
 
-        f = self.failureResultOf(test_d)
-        self.assertIsInstance(f.value, RequestSendFailed)
+        with self.assertRaises(RequestSendFailed):
+            await test_d
 
-    def test_too_big(self) -> None:
+    async def test_too_big(self) -> None:
         """
         Test what happens if a huge response is returned from the remote endpoint.
         """
@@ -622,8 +625,8 @@ class FederationClientTests(HomeserverTestCase):
 
         self.assertEqual(sent, ByteParser.MAX_RESPONSE_SIZE)
 
-        f = self.failureResultOf(test_d)
-        self.assertIsInstance(f.value, RequestSendFailed)
+        with self.assertRaises(RequestSendFailed):
+            await test_d
 
         self.assertTrue(transport.disconnecting)
 
@@ -675,7 +678,7 @@ class FederationClientProxyTests(BaseMultiWorkerStreamTestCase):
             "worker_replication_secret": "secret",
         }
     )
-    def test_proxy_requests_through_federation_sender_worker(self) -> None:
+    async def test_proxy_requests_through_federation_sender_worker(self) -> None:
         """
         Test that all outbound federation requests go through the `federation_sender`
         worker
@@ -722,7 +725,7 @@ class FederationClientProxyTests(BaseMultiWorkerStreamTestCase):
         )
 
         # Make sure the response is as expected back on the main worker
-        res = self.successResultOf(test_request_from_main_process_d)
+        res = await test_request_from_main_process_d
         self.assertEqual(res, {"foo": "bar"})
 
     @override_config(
@@ -731,7 +734,7 @@ class FederationClientProxyTests(BaseMultiWorkerStreamTestCase):
             "worker_replication_secret": "secret",
         }
     )
-    def test_proxy_request_with_network_error_through_federation_sender_worker(
+    async def test_proxy_request_with_network_error_through_federation_sender_worker(
         self,
     ) -> None:
         """
@@ -776,10 +779,10 @@ class FederationClientProxyTests(BaseMultiWorkerStreamTestCase):
         )
 
         # Make sure we get some sort of error back on the main worker
-        failure_res = self.failureResultOf(test_request_from_main_process_d)
-        self.assertIsInstance(failure_res.value, RequestSendFailed)
-        self.assertIsInstance(failure_res.value.inner_exception, HttpResponseException)
-        self.assertEqual(failure_res.value.inner_exception.code, 502)
+        with self.assertRaises(RequestSendFailed) as e:
+            await test_request_from_main_process_d
+        self.assertIsInstance(e.exception.inner_exception, HttpResponseException)
+        self.assertEqual(e.exception.inner_exception.code, 502)
 
     @override_config(
         {
@@ -787,7 +790,7 @@ class FederationClientProxyTests(BaseMultiWorkerStreamTestCase):
             "worker_replication_secret": "secret",
         }
     )
-    def test_proxy_requests_and_discards_hop_by_hop_headers(self) -> None:
+    async def test_proxy_requests_and_discards_hop_by_hop_headers(self) -> None:
         """
         Test to make sure hop-by-hop headers and addional headers defined in the
         `Connection` header are discarded when proxying requests
@@ -845,7 +848,7 @@ class FederationClientProxyTests(BaseMultiWorkerStreamTestCase):
             bodyProducer=ANY,
         )
 
-        res, headers = self.successResultOf(test_request_from_main_process_d)
+        res, headers = await test_request_from_main_process_d
         header_names = set(headers.keys())
 
         # Make sure the response does not include the hop-by-hop headers
@@ -888,7 +891,7 @@ class FederationClientProxyTests(BaseMultiWorkerStreamTestCase):
             "worker_replication_secret": "secret",
         }
     )
-    def test_not_able_to_proxy_requests_through_federation_sender_worker_when_wrong_auth_given(
+    async def test_not_able_to_proxy_requests_through_federation_sender_worker_when_wrong_auth_given(
         self,
     ) -> None:
         """
@@ -929,6 +932,6 @@ class FederationClientProxyTests(BaseMultiWorkerStreamTestCase):
         # worker
         mock_agent_on_federation_sender.request.assert_not_called()
 
-        failure_res = self.failureResultOf(test_request_from_main_process_d)
-        self.assertIsInstance(failure_res.value, HttpResponseException)
-        self.assertEqual(failure_res.value.code, 401)
+        with self.assertRaises(HttpResponseException) as e:
+            await test_request_from_main_process_d
+        self.assertEqual(e.exception.code, 401)

--- a/tests/http/test_matrixfederationclient.py
+++ b/tests/http/test_matrixfederationclient.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from collections.abc import Generator
 from typing import Any
 from unittest.mock import ANY, Mock, create_autospec
 
@@ -19,7 +18,7 @@ from netaddr import IPSet
 from parameterized import parameterized
 
 from twisted.internet import defer
-from twisted.internet.defer import Deferred, TimeoutError
+from twisted.internet.defer import TimeoutError
 from twisted.internet.error import ConnectingCancelledError, DNSLookupError
 from twisted.internet.testing import MemoryReactor, StringTransport
 from twisted.web.client import Agent, ResponseNeverReceived
@@ -70,8 +69,7 @@ class FederationClientTests(HomeserverTestCase):
         happy-path test of a GET request
         """
 
-        @defer.inlineCallbacks
-        def do_request() -> Generator["Deferred[Any]", object, object]:
+        async def do_request() -> object:
             with LoggingContext("one") as context:
                 fetch_d = defer.ensureDeferred(
                     self.cl.get_json("testserv:8008", "foo/bar")
@@ -84,12 +82,11 @@ class FederationClientTests(HomeserverTestCase):
                 check_logcontext(SENTINEL_CONTEXT)
 
                 try:
-                    fetch_res = yield fetch_d
-                    return fetch_res
+                    return await fetch_d
                 finally:
                     check_logcontext(context)
 
-        test_d = do_request()
+        test_d = defer.ensureDeferred(do_request())
 
         self.pump()
 

--- a/tests/http/test_proxyagent.py
+++ b/tests/http/test_proxyagent.py
@@ -312,7 +312,7 @@ class MatrixFederationAgentTests(TestCase):
 
         return http_protocol
 
-    def _test_request_direct_connection(
+    async def _test_request_direct_connection(
         self,
         agent: ProxyAgent,
         scheme: bytes,
@@ -366,65 +366,65 @@ class MatrixFederationAgentTests(TestCase):
 
         self.reactor.advance(0)
 
-        resp = self.successResultOf(d)
-        body = self.successResultOf(treq.content(resp))
+        resp = await d
+        body = await treq.content(resp)
         self.assertEqual(body, b"result")
 
-    def test_http_request(self) -> None:
+    async def test_http_request(self) -> None:
         agent = ProxyAgent(self.reactor)
-        self._test_request_direct_connection(agent, b"http", b"test.com", b"")
+        await self._test_request_direct_connection(agent, b"http", b"test.com", b"")
 
-    def test_https_request(self) -> None:
+    async def test_https_request(self) -> None:
         agent = ProxyAgent(self.reactor, contextFactory=get_test_https_policy())
-        self._test_request_direct_connection(agent, b"https", b"test.com", b"abc")
+        await self._test_request_direct_connection(agent, b"https", b"test.com", b"abc")
 
-    def test_http_request_use_proxy_empty_environment(self) -> None:
+    async def test_http_request_use_proxy_empty_environment(self) -> None:
         agent = ProxyAgent(self.reactor, use_proxy=True)
-        self._test_request_direct_connection(agent, b"http", b"test.com", b"")
+        await self._test_request_direct_connection(agent, b"http", b"test.com", b"")
 
     @patch.dict(os.environ, {"http_proxy": "proxy.com:8888", "NO_PROXY": "test.com"})
-    def test_http_request_via_uppercase_no_proxy(self) -> None:
+    async def test_http_request_via_uppercase_no_proxy(self) -> None:
         agent = ProxyAgent(self.reactor, use_proxy=True)
-        self._test_request_direct_connection(agent, b"http", b"test.com", b"")
+        await self._test_request_direct_connection(agent, b"http", b"test.com", b"")
 
     @patch.dict(
         os.environ, {"http_proxy": "proxy.com:8888", "no_proxy": "test.com,unused.com"}
     )
-    def test_http_request_via_no_proxy(self) -> None:
+    async def test_http_request_via_no_proxy(self) -> None:
         agent = ProxyAgent(self.reactor, use_proxy=True)
-        self._test_request_direct_connection(agent, b"http", b"test.com", b"")
+        await self._test_request_direct_connection(agent, b"http", b"test.com", b"")
 
     @patch.dict(
         os.environ, {"https_proxy": "proxy.com", "no_proxy": "test.com,unused.com"}
     )
-    def test_https_request_via_no_proxy(self) -> None:
+    async def test_https_request_via_no_proxy(self) -> None:
         agent = ProxyAgent(
             self.reactor,
             contextFactory=get_test_https_policy(),
             use_proxy=True,
         )
-        self._test_request_direct_connection(agent, b"https", b"test.com", b"abc")
+        await self._test_request_direct_connection(agent, b"https", b"test.com", b"abc")
 
     @patch.dict(os.environ, {"http_proxy": "proxy.com:8888", "no_proxy": "*"})
-    def test_http_request_via_no_proxy_star(self) -> None:
+    async def test_http_request_via_no_proxy_star(self) -> None:
         agent = ProxyAgent(self.reactor, use_proxy=True)
-        self._test_request_direct_connection(agent, b"http", b"test.com", b"")
+        await self._test_request_direct_connection(agent, b"http", b"test.com", b"")
 
     @patch.dict(os.environ, {"https_proxy": "proxy.com", "no_proxy": "*"})
-    def test_https_request_via_no_proxy_star(self) -> None:
+    async def test_https_request_via_no_proxy_star(self) -> None:
         agent = ProxyAgent(
             self.reactor,
             contextFactory=get_test_https_policy(),
             use_proxy=True,
         )
-        self._test_request_direct_connection(agent, b"https", b"test.com", b"abc")
+        await self._test_request_direct_connection(agent, b"https", b"test.com", b"abc")
 
     @patch.dict(os.environ, {"http_proxy": "proxy.com:8888", "no_proxy": "unused.com"})
-    def test_http_request_via_proxy(self) -> None:
+    async def test_http_request_via_proxy(self) -> None:
         """
         Tests that requests can be made through a proxy.
         """
-        self._do_http_request_via_proxy(
+        await self._do_http_request_via_proxy(
             expect_proxy_ssl=False, expected_auth_credentials=None
         )
 
@@ -432,19 +432,19 @@ class MatrixFederationAgentTests(TestCase):
         os.environ,
         {"http_proxy": "bob:pinkponies@proxy.com:8888", "no_proxy": "unused.com"},
     )
-    def test_http_request_via_proxy_with_auth(self) -> None:
+    async def test_http_request_via_proxy_with_auth(self) -> None:
         """
         Tests that authenticated requests can be made through a proxy.
         """
-        self._do_http_request_via_proxy(
+        await self._do_http_request_via_proxy(
             expect_proxy_ssl=False, expected_auth_credentials=b"bob:pinkponies"
         )
 
     @patch.dict(
         os.environ, {"http_proxy": "https://proxy.com:8888", "no_proxy": "unused.com"}
     )
-    def test_http_request_via_https_proxy(self) -> None:
-        self._do_http_request_via_proxy(
+    async def test_http_request_via_https_proxy(self) -> None:
+        await self._do_http_request_via_proxy(
             expect_proxy_ssl=True, expected_auth_credentials=None
         )
 
@@ -455,15 +455,15 @@ class MatrixFederationAgentTests(TestCase):
             "no_proxy": "unused.com",
         },
     )
-    def test_http_request_via_https_proxy_with_auth(self) -> None:
-        self._do_http_request_via_proxy(
+    async def test_http_request_via_https_proxy_with_auth(self) -> None:
+        await self._do_http_request_via_proxy(
             expect_proxy_ssl=True, expected_auth_credentials=b"bob:pinkponies"
         )
 
     @patch.dict(os.environ, {"https_proxy": "proxy.com", "no_proxy": "unused.com"})
-    def test_https_request_via_proxy(self) -> None:
+    async def test_https_request_via_proxy(self) -> None:
         """Tests that TLS-encrypted requests can be made through a proxy"""
-        self._do_https_request_via_proxy(
+        await self._do_https_request_via_proxy(
             expect_proxy_ssl=False, expected_auth_credentials=None
         )
 
@@ -471,18 +471,18 @@ class MatrixFederationAgentTests(TestCase):
         os.environ,
         {"https_proxy": "bob:pinkponies@proxy.com", "no_proxy": "unused.com"},
     )
-    def test_https_request_via_proxy_with_auth(self) -> None:
+    async def test_https_request_via_proxy_with_auth(self) -> None:
         """Tests that authenticated, TLS-encrypted requests can be made through a proxy"""
-        self._do_https_request_via_proxy(
+        await self._do_https_request_via_proxy(
             expect_proxy_ssl=False, expected_auth_credentials=b"bob:pinkponies"
         )
 
     @patch.dict(
         os.environ, {"https_proxy": "https://proxy.com", "no_proxy": "unused.com"}
     )
-    def test_https_request_via_https_proxy(self) -> None:
+    async def test_https_request_via_https_proxy(self) -> None:
         """Tests that TLS-encrypted requests can be made through a proxy"""
-        self._do_https_request_via_proxy(
+        await self._do_https_request_via_proxy(
             expect_proxy_ssl=True, expected_auth_credentials=None
         )
 
@@ -490,13 +490,13 @@ class MatrixFederationAgentTests(TestCase):
         os.environ,
         {"https_proxy": "https://bob:pinkponies@proxy.com", "no_proxy": "unused.com"},
     )
-    def test_https_request_via_https_proxy_with_auth(self) -> None:
+    async def test_https_request_via_https_proxy_with_auth(self) -> None:
         """Tests that authenticated, TLS-encrypted requests can be made through a proxy"""
-        self._do_https_request_via_proxy(
+        await self._do_https_request_via_proxy(
             expect_proxy_ssl=True, expected_auth_credentials=b"bob:pinkponies"
         )
 
-    def _do_http_request_via_proxy(
+    async def _do_http_request_via_proxy(
         self,
         expect_proxy_ssl: bool = False,
         expected_auth_credentials: bytes | None = None,
@@ -566,11 +566,11 @@ class MatrixFederationAgentTests(TestCase):
 
         self.reactor.advance(0)
 
-        resp = self.successResultOf(d)
-        body = self.successResultOf(treq.content(resp))
+        resp = await d
+        body = await treq.content(resp)
         self.assertEqual(body, b"result")
 
-    def _do_https_request_via_proxy(
+    async def _do_https_request_via_proxy(
         self,
         expect_proxy_ssl: bool = False,
         expected_auth_credentials: bytes | None = None,
@@ -697,12 +697,12 @@ class MatrixFederationAgentTests(TestCase):
 
         self.reactor.advance(0)
 
-        resp = self.successResultOf(d)
-        body = self.successResultOf(treq.content(resp))
+        resp = await d
+        body = await treq.content(resp)
         self.assertEqual(body, b"result")
 
     @patch.dict(os.environ, {"http_proxy": "proxy.com:8888"})
-    def test_http_request_via_proxy_with_blocklist(self) -> None:
+    async def test_http_request_via_proxy_with_blocklist(self) -> None:
         # The blocklist includes the configured proxy IP.
         agent = ProxyAgent(
             BlocklistingReactorWrapper(
@@ -743,12 +743,12 @@ class MatrixFederationAgentTests(TestCase):
 
         self.reactor.advance(0)
 
-        resp = self.successResultOf(d)
-        body = self.successResultOf(treq.content(resp))
+        resp = await d
+        body = await treq.content(resp)
         self.assertEqual(body, b"result")
 
     @patch.dict(os.environ, {"HTTPS_PROXY": "proxy.com"})
-    def test_https_request_via_uppercase_proxy_with_blocklist(self) -> None:
+    async def test_https_request_via_uppercase_proxy_with_blocklist(self) -> None:
         # The blocklist includes the configured proxy IP.
         agent = ProxyAgent(
             BlocklistingReactorWrapper(
@@ -838,8 +838,8 @@ class MatrixFederationAgentTests(TestCase):
 
         self.reactor.advance(0)
 
-        resp = self.successResultOf(d)
-        body = self.successResultOf(treq.content(resp))
+        resp = await d
+        body = await treq.content(resp)
         self.assertEqual(body, b"result")
 
     @patch.dict(os.environ, {"http_proxy": "proxy.com:8888"})

--- a/tests/http/test_simple_client.py
+++ b/tests/http/test_simple_client.py
@@ -34,17 +34,17 @@ class SimpleHttpClientTests(HomeserverTestCase):
 
         self.cl = hs.get_simple_http_client()
 
-    def test_dns_error(self) -> None:
+    async def test_dns_error(self) -> None:
         """
         If the DNS lookup returns an error, it will bubble up.
         """
         d = defer.ensureDeferred(self.cl.get_json("http://testserv2:8008/foo/bar"))
         self.pump()
 
-        f = self.failureResultOf(d)
-        self.assertIsInstance(f.value, DNSLookupError)
+        with self.assertRaises(DNSLookupError):
+            await d
 
-    def test_client_connection_refused(self) -> None:
+    async def test_client_connection_refused(self) -> None:
         d = defer.ensureDeferred(self.cl.get_json("http://testserv:8008/foo/bar"))
 
         self.pump()
@@ -61,11 +61,12 @@ class SimpleHttpClientTests(HomeserverTestCase):
         factory.clientConnectionFailed(None, e)
         self.pump(0.5)
 
-        f = self.failureResultOf(d)
+        with self.assertRaises(Exception) as exc:
+            await d
 
-        self.assertIs(f.value, e)
+        self.assertIs(exc.exception, e)
 
-    def test_client_never_connect(self) -> None:
+    async def test_client_never_connect(self) -> None:
         """
         If the HTTP request is not connected and is timed out, it'll give a
         ConnectingCancelledError or TimeoutError.
@@ -88,11 +89,10 @@ class SimpleHttpClientTests(HomeserverTestCase):
 
         # Push by enough to time it out
         self.reactor.advance(120)
-        f = self.failureResultOf(d)
+        with self.assertRaises(RequestTimedOutError):
+            await d
 
-        self.assertIsInstance(f.value, RequestTimedOutError)
-
-    def test_client_connect_no_response(self) -> None:
+    async def test_client_connect_no_response(self) -> None:
         """
         If the HTTP request is connected, but gets no response before being
         timed out, it'll give a ResponseNeverReceived.
@@ -119,11 +119,10 @@ class SimpleHttpClientTests(HomeserverTestCase):
 
         # Push by enough to time it out
         self.reactor.advance(120)
-        f = self.failureResultOf(d)
+        with self.assertRaises(RequestTimedOutError):
+            await d
 
-        self.assertIsInstance(f.value, RequestTimedOutError)
-
-    def test_client_ip_range_blocklist(self) -> None:
+    async def test_client_ip_range_blocklist(self) -> None:
         """Ensure that Relapse does not try to connect to blocked IPs"""
 
         # Add some DNS entries we'll block
@@ -143,7 +142,8 @@ class SimpleHttpClientTests(HomeserverTestCase):
         clients = self.reactor.tcpClients
         self.assertEqual(len(clients), 0)
 
-        self.failureResultOf(d, DNSLookupError)
+        with self.assertRaises(DNSLookupError):
+            await d
 
         # Try making a POST request to a blocked IPv6 address
         # -------------------------------------------------------
@@ -160,7 +160,8 @@ class SimpleHttpClientTests(HomeserverTestCase):
         self.assertEqual(len(clients), 0)
 
         # Check that it was due to a blocked DNS lookup
-        self.failureResultOf(d, DNSLookupError)
+        with self.assertRaises(DNSLookupError):
+            await d
 
         # Try making a GET request to a non-blocked IPv4 address
         # ----------------------------------------------------------
@@ -178,4 +179,5 @@ class SimpleHttpClientTests(HomeserverTestCase):
         self.assertNotEqual(len(clients), 0)
 
         # Connection will still fail as this IP address does not resolve to anything
-        self.failureResultOf(d, RequestTimedOutError)
+        with self.assertRaises(RequestTimedOutError):
+            await d

--- a/tests/logging/test_opentracing.py
+++ b/tests/logging/test_opentracing.py
@@ -147,7 +147,7 @@ class LogContextScopeManagerTestCase(TestCase):
             self._reporter.get_spans(), [scope2.span, scope1.span, root_scope.span]
         )
 
-    def test_overlapping_spans(self) -> None:
+    async def test_overlapping_spans(self) -> None:
         """Overlapping spans which are not neatly nested should work"""
         reactor = MemoryReactorClock()
         clock = Clock(reactor)
@@ -192,7 +192,7 @@ class LogContextScopeManagerTestCase(TestCase):
             # let the tasks complete
             reactor.pump((2,) * 8)
 
-            self.successResultOf(d1)
+            await d1
             self.assertIsNone(self._tracer.active_span)
 
         # the spans should be reported in order of their finishing: task 1, task 2,
@@ -223,7 +223,7 @@ class LogContextScopeManagerTestCase(TestCase):
             ["fixture_sync_func"],
         )
 
-    def test_trace_decorator_deferred(self) -> None:
+    async def test_trace_decorator_deferred(self) -> None:
         """
         Test whether we can use `@trace_with_opname` (`@trace`) and `@tag_args`
         with functions that return deferreds
@@ -239,7 +239,7 @@ class LogContextScopeManagerTestCase(TestCase):
 
             result_d1 = fixture_deferred_func()
 
-            self.assertEqual(self.successResultOf(result_d1), "foo")
+            self.assertEqual(await result_d1, "foo")
 
         # the span should have been reported
         self.assertEqual(
@@ -247,7 +247,7 @@ class LogContextScopeManagerTestCase(TestCase):
             ["fixture_deferred_func"],
         )
 
-    def test_trace_decorator_async(self) -> None:
+    async def test_trace_decorator_async(self) -> None:
         """
         Test whether we can use `@trace_with_opname` (`@trace`) and `@tag_args`
         with async functions
@@ -261,7 +261,7 @@ class LogContextScopeManagerTestCase(TestCase):
 
             d1 = defer.ensureDeferred(fixture_async_func())
 
-            self.assertEqual(self.successResultOf(d1), "foo")
+            self.assertEqual(await d1, "foo")
 
         # the span should have been reported
         self.assertEqual(
@@ -269,7 +269,7 @@ class LogContextScopeManagerTestCase(TestCase):
             ["fixture_async_func"],
         )
 
-    def test_trace_decorator_awaitable_return(self) -> None:
+    async def test_trace_decorator_awaitable_return(self) -> None:
         """
         Test whether we can use `@trace_with_opname` (`@trace`) and `@tag_args`
         with functions that return an awaitable (e.g. a coroutine)
@@ -292,7 +292,7 @@ class LogContextScopeManagerTestCase(TestCase):
 
             d1 = defer.ensureDeferred(runner())
 
-            self.assertEqual(self.successResultOf(d1), "foo")
+            self.assertEqual(await d1, "foo")
 
         # the span should have been reported
         self.assertEqual(

--- a/tests/module_api/test_api.py
+++ b/tests/module_api/test_api.py
@@ -14,7 +14,6 @@
 from typing import Any
 from unittest.mock import AsyncMock, Mock
 
-from twisted.internet import defer
 from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EduTypes, EventTypes
@@ -473,9 +472,7 @@ class ModuleApiTestCase(BaseModuleApiTestCase):
 
         # Make Peter invite Lesley to the room.
         self.get_success(
-            defer.ensureDeferred(
-                self.module_api.update_room_membership(peter, lesley, room_id, "invite")
-            )
+            self.module_api.update_room_membership(peter, lesley, room_id, "invite")
         )
 
         res = self.helper.get_state(
@@ -495,9 +492,7 @@ class ModuleApiTestCase(BaseModuleApiTestCase):
 
         # Make lesley join it.
         self.get_success(
-            defer.ensureDeferred(
-                self.module_api.update_room_membership(lesley, lesley, room_id, "join")
-            )
+            self.module_api.update_room_membership(lesley, lesley, room_id, "join")
         )
 
         # Check that the membership of lesley in the room is "join".
@@ -516,9 +511,7 @@ class ModuleApiTestCase(BaseModuleApiTestCase):
 
         # Make peter kick lesley from the room.
         self.get_success(
-            defer.ensureDeferred(
-                self.module_api.update_room_membership(peter, lesley, room_id, "leave")
-            )
+            self.module_api.update_room_membership(peter, lesley, room_id, "leave")
         )
 
         # Check that the membership of lesley in the room is "leave".
@@ -532,13 +525,11 @@ class ModuleApiTestCase(BaseModuleApiTestCase):
         self.assertEqual(res["membership"], "leave")
 
         # Try to send a membership update from a non-local user and check that it fails.
-        d = defer.ensureDeferred(
-            self.module_api.update_room_membership(
-                "@nicolas:otherserver.com",
-                lesley,
-                room_id,
-                "invite",
-            )
+        d = self.module_api.update_room_membership(
+            "@nicolas:otherserver.com",
+            lesley,
+            room_id,
+            "invite",
         )
 
         self.get_failure(d, RuntimeError)
@@ -547,9 +538,7 @@ class ModuleApiTestCase(BaseModuleApiTestCase):
         # default (localpart + no avatar) profile.
         simone = "@simone:" + self.hs.config.server.server_name
         self.get_success(
-            defer.ensureDeferred(
-                self.module_api.update_room_membership(peter, simone, room_id, "invite")
-            )
+            self.module_api.update_room_membership(peter, simone, room_id, "invite")
         )
 
         res = self.helper.get_state(
@@ -574,7 +563,7 @@ class ModuleApiTestCase(BaseModuleApiTestCase):
         # Given that the join is to be faked, we expect the relevant join event not to
         # be persisted and the module API method to raise that.
         self.get_failure(
-            defer.ensureDeferred(
+            (
                 self.module_api.update_room_membership(
                     sender=f"@user:{self.module_api.server_name}",
                     target=f"@user:{self.module_api.server_name}",
@@ -599,9 +588,7 @@ class ModuleApiTestCase(BaseModuleApiTestCase):
         self.helper.send_state(room_id, "org.matrix.test", {}, tok=tok)
 
         # Check that the module API can successfully fetch state for the room.
-        state = self.get_success(
-            defer.ensureDeferred(self.module_api.get_room_state(room_id))
-        )
+        state = self.get_success(self.module_api.get_room_state(room_id))
 
         # Check that a few standard events are in the returned state.
         self.assertIn((EventTypes.Create, ""), state)
@@ -653,14 +640,12 @@ class ModuleApiTestCase(BaseModuleApiTestCase):
 
         # Change the .m.rule.message actions to not notify on new messages.
         self.get_success(
-            defer.ensureDeferred(
-                self.module_api.set_push_rule_action(
-                    user_id=user_id,
-                    scope="global",
-                    kind="underride",
-                    rule_id=".m.rule.message",
-                    actions=["dont_notify"],
-                )
+            self.module_api.set_push_rule_action(
+                user_id=user_id,
+                scope="global",
+                kind="underride",
+                rule_id=".m.rule.message",
+                actions=["dont_notify"],
             )
         )
 
@@ -926,10 +911,8 @@ def _test_sending_local_online_presence_to_local_user(
     # Trigger sending local online presence. We expect this information
     # to be saved to the database where all processes can access it.
     # Note that we're syncing via the master.
-    d = defer.ensureDeferred(
-        module_api_to_use.send_local_online_presence_to(
-            [test_case.presence_receiver_id],
-        )
+    d = module_api_to_use.send_local_online_presence_to(
+        [test_case.presence_receiver_id],
     )
 
     if test_with_workers:
@@ -986,12 +969,10 @@ def _test_sending_local_online_presence_to_local_user(
     test_case.assertEqual(len(presence_updates), 1)
 
     # Now trigger sending local online presence.
-    d = defer.ensureDeferred(
-        module_api_to_use.send_local_online_presence_to(
-            [
-                test_case.presence_receiver_id,
-            ]
-        )
+    d = module_api_to_use.send_local_online_presence_to(
+        [
+            test_case.presence_receiver_id,
+        ]
     )
 
     if test_with_workers:

--- a/tests/module_api/test_api.py
+++ b/tests/module_api/test_api.py
@@ -14,6 +14,7 @@
 from typing import Any
 from unittest.mock import AsyncMock, Mock
 
+from twisted.internet import defer
 from twisted.internet.testing import MemoryReactor
 
 from relapse.api.constants import EduTypes, EventTypes
@@ -911,8 +912,10 @@ def _test_sending_local_online_presence_to_local_user(
     # Trigger sending local online presence. We expect this information
     # to be saved to the database where all processes can access it.
     # Note that we're syncing via the master.
-    d = module_api_to_use.send_local_online_presence_to(
-        [test_case.presence_receiver_id],
+    d = defer.ensureDeferred(
+        module_api_to_use.send_local_online_presence_to(
+            [test_case.presence_receiver_id]
+        )
     )
 
     if test_with_workers:
@@ -969,10 +972,10 @@ def _test_sending_local_online_presence_to_local_user(
     test_case.assertEqual(len(presence_updates), 1)
 
     # Now trigger sending local online presence.
-    d = module_api_to_use.send_local_online_presence_to(
-        [
-            test_case.presence_receiver_id,
-        ]
+    d = defer.ensureDeferred(
+        module_api_to_use.send_local_online_presence_to(
+            [test_case.presence_receiver_id]
+        )
     )
 
     if test_with_workers:

--- a/tests/rest/client/test_transactions.py
+++ b/tests/rest/client/test_transactions.py
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections.abc import Generator
 from http import HTTPStatus
-from typing import Any, cast
+from typing import cast
 from unittest.mock import AsyncMock, Mock, call
 
 from twisted.internet import defer, reactor as _reactor
@@ -49,24 +48,22 @@ class HttpTransactionCacheTestCase(unittest.TestCase):
         self.mock_requester.is_guest = False
         self.mock_requester.access_token_id = 1234
 
-    @defer.inlineCallbacks
-    def test_executes_given_function(
+    async def test_executes_given_function(
         self,
-    ) -> Generator["defer.Deferred[Any]", object, None]:
+    ) -> None:
         cb = AsyncMock(return_value=self.mock_http_response)
-        res = yield self.cache.fetch_or_execute_request(
+        res = await self.cache.fetch_or_execute_request(
             self.mock_request, self.mock_requester, cb, "some_arg", keyword="arg"
         )
         cb.assert_called_once_with("some_arg", keyword="arg")
         self.assertEqual(res, self.mock_http_response)
 
-    @defer.inlineCallbacks
-    def test_deduplicates_based_on_key(
+    async def test_deduplicates_based_on_key(
         self,
-    ) -> Generator["defer.Deferred[Any]", object, None]:
+    ) -> None:
         cb = AsyncMock(return_value=self.mock_http_response)
         for i in range(3):  # invoke multiple times
-            res = yield self.cache.fetch_or_execute_request(
+            res = await self.cache.fetch_or_execute_request(
                 self.mock_request,
                 self.mock_requester,
                 cb,
@@ -78,34 +75,32 @@ class HttpTransactionCacheTestCase(unittest.TestCase):
         # expect only a single call to do the work
         cb.assert_called_once_with("some_arg", keyword="arg", changing_args=0)
 
-    @defer.inlineCallbacks
-    def test_logcontexts_with_async_result(
+    async def test_logcontexts_with_async_result(
         self,
-    ) -> Generator["defer.Deferred[Any]", object, None]:
-        @defer.inlineCallbacks
-        def cb() -> Generator["defer.Deferred[object]", object, tuple[int, JsonDict]]:
-            yield Clock(reactor).sleep(0)
+    ) -> None:
+        async def cb() -> tuple[int, JsonDict]:
+            await Clock(reactor).sleep(0)
             return 1, {}
 
-        @defer.inlineCallbacks
-        def test() -> Generator["defer.Deferred[Any]", object, None]:
+        async def test() -> None:
             with LoggingContext("c") as c1:
-                res = yield self.cache.fetch_or_execute_request(
+                res = await self.cache.fetch_or_execute_request(
                     self.mock_request, self.mock_requester, cb
                 )
                 self.assertIs(current_context(), c1)
                 self.assertEqual(res, (1, {}))
 
         # run the test twice in parallel
-        d = defer.gatherResults([test(), test()])
+        d = defer.gatherResults(
+            [defer.ensureDeferred(test()), defer.ensureDeferred(test())]
+        )
         self.assertIs(current_context(), SENTINEL_CONTEXT)
-        yield d
+        await d
         self.assertIs(current_context(), SENTINEL_CONTEXT)
 
-    @defer.inlineCallbacks
-    def test_does_not_cache_exceptions(
+    async def test_does_not_cache_exceptions(
         self,
-    ) -> Generator["defer.Deferred[Any]", object, None]:
+    ) -> None:
         """Checks that, if the callback throws an exception, it is called again
         for the next request.
         """
@@ -121,23 +116,22 @@ class HttpTransactionCacheTestCase(unittest.TestCase):
 
         with LoggingContext("test") as test_context:
             try:
-                yield self.cache.fetch_or_execute_request(
+                await self.cache.fetch_or_execute_request(
                     self.mock_request, self.mock_requester, cb
                 )
             except Exception as e:
                 self.assertEqual(e.args[0], "boo")
             self.assertIs(current_context(), test_context)
 
-            res = yield self.cache.fetch_or_execute_request(
+            res = await self.cache.fetch_or_execute_request(
                 self.mock_request, self.mock_requester, cb
             )
             self.assertEqual(res, self.mock_http_response)
             self.assertIs(current_context(), test_context)
 
-    @defer.inlineCallbacks
-    def test_does_not_cache_failures(
+    async def test_does_not_cache_failures(
         self,
-    ) -> Generator["defer.Deferred[Any]", object, None]:
+    ) -> None:
         """Checks that, if the callback returns a failure, it is called again
         for the next request.
         """
@@ -153,29 +147,28 @@ class HttpTransactionCacheTestCase(unittest.TestCase):
 
         with LoggingContext("test") as test_context:
             try:
-                yield self.cache.fetch_or_execute_request(
+                await self.cache.fetch_or_execute_request(
                     self.mock_request, self.mock_requester, cb
                 )
             except Exception as e:
                 self.assertEqual(e.args[0], "boo")
             self.assertIs(current_context(), test_context)
 
-            res = yield self.cache.fetch_or_execute_request(
+            res = await self.cache.fetch_or_execute_request(
                 self.mock_request, self.mock_requester, cb
             )
             self.assertEqual(res, self.mock_http_response)
             self.assertIs(current_context(), test_context)
 
-    @defer.inlineCallbacks
-    def test_cleans_up(self) -> Generator["defer.Deferred[Any]", object, None]:
+    async def test_cleans_up(self) -> None:
         cb = AsyncMock(return_value=self.mock_http_response)
-        yield self.cache.fetch_or_execute_request(
+        await self.cache.fetch_or_execute_request(
             self.mock_request, self.mock_requester, cb, "an arg"
         )
         # should NOT have cleaned up yet
         self.clock.advance_time_msec(CLEANUP_PERIOD_MS / 2)
 
-        yield self.cache.fetch_or_execute_request(
+        await self.cache.fetch_or_execute_request(
             self.mock_request, self.mock_requester, cb, "an arg"
         )
         # still using cache
@@ -183,7 +176,7 @@ class HttpTransactionCacheTestCase(unittest.TestCase):
 
         self.clock.advance_time_msec(CLEANUP_PERIOD_MS)
 
-        yield self.cache.fetch_or_execute_request(
+        await self.cache.fetch_or_execute_request(
             self.mock_request, self.mock_requester, cb, "an arg"
         )
         # no longer using cache

--- a/tests/state/test_v2.py
+++ b/tests/state/test_v2.py
@@ -172,7 +172,7 @@ INITIAL_EDGES = ["START", "IMZ", "IMC", "IMB", "IJR", "IPOWER", "IMA", "CREATE"]
 
 
 class StateTestCase(unittest.TestCase):
-    def test_ban_vs_pl(self) -> None:
+    async def test_ban_vs_pl(self) -> None:
         events = [
             FakeEvent(
                 id="PA",
@@ -208,9 +208,9 @@ class StateTestCase(unittest.TestCase):
 
         expected_state_ids = ["PA", "MA", "MB"]
 
-        self.do_check(events, edges, expected_state_ids)
+        await self.do_check(events, edges, expected_state_ids)
 
-    def test_join_rule_evasion(self) -> None:
+    async def test_join_rule_evasion(self) -> None:
         events = [
             FakeEvent(
                 id="JR",
@@ -232,9 +232,9 @@ class StateTestCase(unittest.TestCase):
 
         expected_state_ids = ["JR"]
 
-        self.do_check(events, edges, expected_state_ids)
+        await self.do_check(events, edges, expected_state_ids)
 
-    def test_offtopic_pl(self) -> None:
+    async def test_offtopic_pl(self) -> None:
         events = [
             FakeEvent(
                 id="PA",
@@ -263,9 +263,9 @@ class StateTestCase(unittest.TestCase):
 
         expected_state_ids = ["PC"]
 
-        self.do_check(events, edges, expected_state_ids)
+        await self.do_check(events, edges, expected_state_ids)
 
-    def test_topic_basic(self) -> None:
+    async def test_topic_basic(self) -> None:
         events = [
             FakeEvent(
                 id="T1", sender=ALICE, type=EventTypes.Topic, state_key="", content={}
@@ -303,9 +303,9 @@ class StateTestCase(unittest.TestCase):
 
         expected_state_ids = ["PA2", "T2"]
 
-        self.do_check(events, edges, expected_state_ids)
+        await self.do_check(events, edges, expected_state_ids)
 
-    def test_topic_reset(self) -> None:
+    async def test_topic_reset(self) -> None:
         events = [
             FakeEvent(
                 id="T1", sender=ALICE, type=EventTypes.Topic, state_key="", content={}
@@ -333,9 +333,9 @@ class StateTestCase(unittest.TestCase):
 
         expected_state_ids = ["T1", "MB", "PA"]
 
-        self.do_check(events, edges, expected_state_ids)
+        await self.do_check(events, edges, expected_state_ids)
 
-    def test_topic(self) -> None:
+    async def test_topic(self) -> None:
         events = [
             FakeEvent(
                 id="T1", sender=ALICE, type=EventTypes.Topic, state_key="", content={}
@@ -386,9 +386,9 @@ class StateTestCase(unittest.TestCase):
 
         expected_state_ids = ["T4", "PA2"]
 
-        self.do_check(events, edges, expected_state_ids)
+        await self.do_check(events, edges, expected_state_ids)
 
-    def test_mainline_sort(self) -> None:
+    async def test_mainline_sort(self) -> None:
         """Tests that the mainline ordering works correctly."""
 
         events = [
@@ -440,9 +440,9 @@ class StateTestCase(unittest.TestCase):
         # it being sent *after* T3.
         expected_state_ids = ["T3", "PA2"]
 
-        self.do_check(events, edges, expected_state_ids)
+        await self.do_check(events, edges, expected_state_ids)
 
-    def do_check(
+    async def do_check(
         self,
         events: list[FakeEvent],
         edges: list[list[str]],
@@ -501,7 +501,7 @@ class StateTestCase(unittest.TestCase):
                     state_res_store=TestStateResolutionStore(event_map),
                 )
 
-                state_before = self.successResultOf(defer.ensureDeferred(state_d))
+                state_before = await defer.ensureDeferred(state_d)
 
             state_after = dict(state_before)
             if fake_event.state_key is not None:
@@ -653,7 +653,7 @@ class SimpleParamStateTestCase(unittest.TestCase):
             ]
         }
 
-    def test_event_map_none(self) -> None:
+    async def test_event_map_none(self) -> None:
         # Test that we correctly handle passing `None` as the event_map
 
         state_d = resolve_events_with_store(
@@ -665,7 +665,7 @@ class SimpleParamStateTestCase(unittest.TestCase):
             state_res_store=TestStateResolutionStore(self.event_map),
         )
 
-        state = self.successResultOf(defer.ensureDeferred(state_d))
+        state = await defer.ensureDeferred(state_d)
 
         self.assert_dict(self.expected_combined_state, state)
 
@@ -675,7 +675,7 @@ class AuthChainDifferenceTestCase(unittest.TestCase):
     events.
     """
 
-    def test_simple(self) -> None:
+    async def test_simple(self) -> None:
         # Test getting the auth difference for a simple chain with a single
         # unpersisted event:
         #
@@ -720,11 +720,11 @@ class AuthChainDifferenceTestCase(unittest.TestCase):
         diff_d = _get_auth_chain_difference(
             ROOM_ID, state_sets, unpersited_events, store
         )
-        difference = self.successResultOf(defer.ensureDeferred(diff_d))
+        difference = await defer.ensureDeferred(diff_d)
 
         self.assertEqual(difference, {c.event_id})
 
-    def test_multiple_unpersisted_chain(self) -> None:
+    async def test_multiple_unpersisted_chain(self) -> None:
         # Test getting the auth difference for a simple chain with multiple
         # unpersisted events:
         #
@@ -777,11 +777,11 @@ class AuthChainDifferenceTestCase(unittest.TestCase):
         diff_d = _get_auth_chain_difference(
             ROOM_ID, state_sets, unpersited_events, store
         )
-        difference = self.successResultOf(defer.ensureDeferred(diff_d))
+        difference = await defer.ensureDeferred(diff_d)
 
         self.assertEqual(difference, {d.event_id, c.event_id})
 
-    def test_unpersisted_events_different_sets(self) -> None:
+    async def test_unpersisted_events_different_sets(self) -> None:
         # Test getting the auth difference for with multiple unpersisted events
         # in different branches:
         #
@@ -844,7 +844,7 @@ class AuthChainDifferenceTestCase(unittest.TestCase):
         diff_d = _get_auth_chain_difference(
             ROOM_ID, state_sets, unpersited_events, store
         )
-        difference = self.successResultOf(defer.ensureDeferred(diff_d))
+        difference = await defer.ensureDeferred(diff_d)
 
         self.assertEqual(difference, {d.event_id, e.event_id})
 

--- a/tests/storage/test_appservice.py
+++ b/tests/storage/test_appservice.py
@@ -183,9 +183,7 @@ class ApplicationServiceTransactionStoreTestCase(unittest.HomeserverTestCase):
             self._set_state(self.as_list[0]["id"], ApplicationServiceState.UP)
         )
         service = Mock(id=self.as_list[0]["id"])
-        state = self.get_success(
-            defer.ensureDeferred(self.store.get_appservice_state(service))
-        )
+        state = self.get_success(self.store.get_appservice_state(service))
         self.assertEqual(ApplicationServiceState.UP, state)
 
     def test_get_appservice_state_down(
@@ -258,10 +256,8 @@ class ApplicationServiceTransactionStoreTestCase(unittest.HomeserverTestCase):
         service = Mock(id=self.as_list[0]["id"])
         events = cast(list[EventBase], [Mock(event_id="e1"), Mock(event_id="e2")])
         txn = self.get_success(
-            defer.ensureDeferred(
-                self.store.create_appservice_txn(
-                    service, events, [], [], {}, {}, DeviceListUpdates()
-                )
+            self.store.create_appservice_txn(
+                service, events, [], [], {}, {}, DeviceListUpdates()
             )
         )
         self.assertEqual(txn.id, 1)

--- a/tests/storage/test_base.py
+++ b/tests/storage/test_base.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from collections import OrderedDict
-from collections.abc import Generator
 from unittest.mock import Mock, call, patch
 
 from twisted.internet import defer
@@ -108,11 +107,10 @@ class SQLBaseStoreTestCase(unittest.TestCase):
             self.execute_batch_patcher.stop()
             self.execute_values_patcher.stop()
 
-    @defer.inlineCallbacks
-    def test_insert_1col(self) -> Generator["defer.Deferred[object]", object, None]:
+    async def test_insert_1col(self) -> None:
         self.mock_txn.rowcount = 1
 
-        yield defer.ensureDeferred(
+        await defer.ensureDeferred(
             self.datastore.db_pool.simple_insert(
                 table="tablename", values={"columname": "Value"}
             )
@@ -122,11 +120,10 @@ class SQLBaseStoreTestCase(unittest.TestCase):
             "INSERT INTO tablename (columname) VALUES(?)", ("Value",)
         )
 
-    @defer.inlineCallbacks
-    def test_insert_3cols(self) -> Generator["defer.Deferred[object]", object, None]:
+    async def test_insert_3cols(self) -> None:
         self.mock_txn.rowcount = 1
 
-        yield defer.ensureDeferred(
+        await defer.ensureDeferred(
             self.datastore.db_pool.simple_insert(
                 table="tablename",
                 # Use OrderedDict() so we can assert on the SQL generated
@@ -138,9 +135,8 @@ class SQLBaseStoreTestCase(unittest.TestCase):
             "INSERT INTO tablename (colA, colB, colC) VALUES(?, ?, ?)", (1, 2, 3)
         )
 
-    @defer.inlineCallbacks
-    def test_insert_many(self) -> Generator["defer.Deferred[object]", object, None]:
-        yield defer.ensureDeferred(
+    async def test_insert_many(self) -> None:
+        await defer.ensureDeferred(
             self.datastore.db_pool.simple_insert_many(
                 table="tablename",
                 keys=(
@@ -172,11 +168,10 @@ class SQLBaseStoreTestCase(unittest.TestCase):
                 [("val1", "val2"), ("val3", "val4")],
             )
 
-    @defer.inlineCallbacks
-    def test_insert_many_no_iterable(
+    async def test_insert_many_no_iterable(
         self,
-    ) -> Generator["defer.Deferred[object]", object, None]:
-        yield defer.ensureDeferred(
+    ) -> None:
+        await defer.ensureDeferred(
             self.datastore.db_pool.simple_insert_many(
                 table="tablename",
                 keys=(
@@ -193,12 +188,11 @@ class SQLBaseStoreTestCase(unittest.TestCase):
         else:
             self.mock_txn.executemany.assert_not_called()
 
-    @defer.inlineCallbacks
-    def test_select_one_1col(self) -> Generator["defer.Deferred[object]", object, None]:
+    async def test_select_one_1col(self) -> None:
         self.mock_txn.rowcount = 1
         self.mock_txn.__iter__ = Mock(return_value=iter([("Value",)]))
 
-        value = yield defer.ensureDeferred(
+        value = await defer.ensureDeferred(
             self.datastore.db_pool.simple_select_one_onecol(
                 table="tablename", keyvalues={"keycol": "TheKey"}, retcol="retcol"
             )
@@ -209,12 +203,11 @@ class SQLBaseStoreTestCase(unittest.TestCase):
             "SELECT retcol FROM tablename WHERE keycol = ?", ["TheKey"]
         )
 
-    @defer.inlineCallbacks
-    def test_select_one_3col(self) -> Generator["defer.Deferred[object]", object, None]:
+    async def test_select_one_3col(self) -> None:
         self.mock_txn.rowcount = 1
         self.mock_txn.fetchone.return_value = (1, 2, 3)
 
-        ret = yield defer.ensureDeferred(
+        ret = await defer.ensureDeferred(
             self.datastore.db_pool.simple_select_one(
                 table="tablename",
                 keyvalues={"keycol": "TheKey"},
@@ -227,14 +220,13 @@ class SQLBaseStoreTestCase(unittest.TestCase):
             "SELECT colA, colB, colC FROM tablename WHERE keycol = ?", ["TheKey"]
         )
 
-    @defer.inlineCallbacks
-    def test_select_one_missing(
+    async def test_select_one_missing(
         self,
-    ) -> Generator["defer.Deferred[object]", object, None]:
+    ) -> None:
         self.mock_txn.rowcount = 0
         self.mock_txn.fetchone.return_value = None
 
-        ret = yield defer.ensureDeferred(
+        ret = await defer.ensureDeferred(
             self.datastore.db_pool.simple_select_one(
                 table="tablename",
                 keyvalues={"keycol": "Not here"},
@@ -245,13 +237,12 @@ class SQLBaseStoreTestCase(unittest.TestCase):
 
         self.assertIsNone(ret)
 
-    @defer.inlineCallbacks
-    def test_select_list(self) -> Generator["defer.Deferred[object]", object, None]:
+    async def test_select_list(self) -> None:
         self.mock_txn.rowcount = 3
         self.mock_txn.fetchall.return_value = [(1,), (2,), (3,)]
         self.mock_txn.description = (("colA", None, None, None, None, None, None),)
 
-        ret = yield defer.ensureDeferred(
+        ret = await defer.ensureDeferred(
             self.datastore.db_pool.simple_select_list(
                 table="tablename", keyvalues={"keycol": "A set"}, retcols=["colA"]
             )
@@ -262,14 +253,13 @@ class SQLBaseStoreTestCase(unittest.TestCase):
             "SELECT colA FROM tablename WHERE keycol = ?", ["A set"]
         )
 
-    @defer.inlineCallbacks
-    def test_select_many_batch(
+    async def test_select_many_batch(
         self,
-    ) -> Generator["defer.Deferred[object]", object, None]:
+    ) -> None:
         self.mock_txn.rowcount = 3
         self.mock_txn.fetchall.side_effect = [[(1,), (2,)], [(3,)]]
 
-        ret = yield defer.ensureDeferred(
+        ret = await defer.ensureDeferred(
             self.datastore.db_pool.simple_select_many_batch(
                 table="tablename",
                 column="col1",
@@ -310,11 +300,10 @@ class SQLBaseStoreTestCase(unittest.TestCase):
         self.mock_txn.execute.assert_not_called()
         self.assertEqual([], ret)
 
-    @defer.inlineCallbacks
-    def test_update_one_1col(self) -> Generator["defer.Deferred[object]", object, None]:
+    async def test_update_one_1col(self) -> None:
         self.mock_txn.rowcount = 1
 
-        yield defer.ensureDeferred(
+        await defer.ensureDeferred(
             self.datastore.db_pool.simple_update_one(
                 table="tablename",
                 keyvalues={"keycol": "TheKey"},
@@ -327,13 +316,12 @@ class SQLBaseStoreTestCase(unittest.TestCase):
             ["New Value", "TheKey"],
         )
 
-    @defer.inlineCallbacks
-    def test_update_one_4cols(
+    async def test_update_one_4cols(
         self,
-    ) -> Generator["defer.Deferred[object]", object, None]:
+    ) -> None:
         self.mock_txn.rowcount = 1
 
-        yield defer.ensureDeferred(
+        await defer.ensureDeferred(
             self.datastore.db_pool.simple_update_one(
                 table="tablename",
                 keyvalues=OrderedDict([("colA", 1), ("colB", 2)]),
@@ -346,9 +334,8 @@ class SQLBaseStoreTestCase(unittest.TestCase):
             [3, 4, 1, 2],
         )
 
-    @defer.inlineCallbacks
-    def test_update_many(self) -> Generator["defer.Deferred[object]", object, None]:
-        yield defer.ensureDeferred(
+    async def test_update_many(self) -> None:
+        await defer.ensureDeferred(
             self.datastore.db_pool.simple_update_many(
                 table="tablename",
                 key_names=("col1", "col2"),
@@ -373,7 +360,7 @@ class SQLBaseStoreTestCase(unittest.TestCase):
 
         # key_values and value_values must be the same length.
         with self.assertRaises(ValueError):
-            yield defer.ensureDeferred(
+            await defer.ensureDeferred(
                 self.datastore.db_pool.simple_update_many(
                     table="tablename",
                     key_names=("col1", "col2"),
@@ -384,11 +371,10 @@ class SQLBaseStoreTestCase(unittest.TestCase):
                 )
             )
 
-    @defer.inlineCallbacks
-    def test_update_many_no_iterable(
+    async def test_update_many_no_iterable(
         self,
-    ) -> Generator["defer.Deferred[object]", object, None]:
-        yield defer.ensureDeferred(
+    ) -> None:
+        await defer.ensureDeferred(
             self.datastore.db_pool.simple_update_many(
                 table="tablename",
                 key_names=("col1", "col2"),
@@ -404,11 +390,10 @@ class SQLBaseStoreTestCase(unittest.TestCase):
         else:
             self.mock_txn.executemany.assert_not_called()
 
-    @defer.inlineCallbacks
-    def test_delete_one(self) -> Generator["defer.Deferred[object]", object, None]:
+    async def test_delete_one(self) -> None:
         self.mock_txn.rowcount = 1
 
-        yield defer.ensureDeferred(
+        await defer.ensureDeferred(
             self.datastore.db_pool.simple_delete_one(
                 table="tablename", keyvalues={"keycol": "Go away"}
             )
@@ -418,11 +403,10 @@ class SQLBaseStoreTestCase(unittest.TestCase):
             "DELETE FROM tablename WHERE keycol = ?", ["Go away"]
         )
 
-    @defer.inlineCallbacks
-    def test_delete_many(self) -> Generator["defer.Deferred[object]", object, None]:
+    async def test_delete_many(self) -> None:
         self.mock_txn.rowcount = 2
 
-        result = yield defer.ensureDeferred(
+        result = await defer.ensureDeferred(
             self.datastore.db_pool.simple_delete_many(
                 table="tablename",
                 column="col1",
@@ -438,11 +422,10 @@ class SQLBaseStoreTestCase(unittest.TestCase):
         )
         self.assertEqual(result, 2)
 
-    @defer.inlineCallbacks
-    def test_delete_many_no_iterable(
+    async def test_delete_many_no_iterable(
         self,
-    ) -> Generator["defer.Deferred[object]", object, None]:
-        result = yield defer.ensureDeferred(
+    ) -> None:
+        result = await defer.ensureDeferred(
             self.datastore.db_pool.simple_delete_many(
                 table="tablename",
                 column="col1",
@@ -455,13 +438,12 @@ class SQLBaseStoreTestCase(unittest.TestCase):
         self.mock_txn.execute.assert_not_called()
         self.assertEqual(result, 0)
 
-    @defer.inlineCallbacks
-    def test_delete_many_no_keyvalues(
+    async def test_delete_many_no_keyvalues(
         self,
-    ) -> Generator["defer.Deferred[object]", object, None]:
+    ) -> None:
         self.mock_txn.rowcount = 2
 
-        result = yield defer.ensureDeferred(
+        result = await defer.ensureDeferred(
             self.datastore.db_pool.simple_delete_many(
                 table="tablename",
                 column="col1",
@@ -476,11 +458,10 @@ class SQLBaseStoreTestCase(unittest.TestCase):
         )
         self.assertEqual(result, 2)
 
-    @defer.inlineCallbacks
-    def test_upsert(self) -> Generator["defer.Deferred[object]", object, None]:
+    async def test_upsert(self) -> None:
         self.mock_txn.rowcount = 1
 
-        result = yield defer.ensureDeferred(
+        result = await defer.ensureDeferred(
             self.datastore.db_pool.simple_upsert(
                 table="tablename",
                 keyvalues={"columnname": "oldvalue"},
@@ -494,13 +475,12 @@ class SQLBaseStoreTestCase(unittest.TestCase):
         )
         self.assertTrue(result)
 
-    @defer.inlineCallbacks
-    def test_upsert_no_values(
+    async def test_upsert_no_values(
         self,
-    ) -> Generator["defer.Deferred[object]", object, None]:
+    ) -> None:
         self.mock_txn.rowcount = 1
 
-        result = yield defer.ensureDeferred(
+        result = await defer.ensureDeferred(
             self.datastore.db_pool.simple_upsert(
                 table="tablename",
                 keyvalues={"columnname": "value"},
@@ -515,13 +495,12 @@ class SQLBaseStoreTestCase(unittest.TestCase):
         )
         self.assertTrue(result)
 
-    @defer.inlineCallbacks
-    def test_upsert_with_insertion(
+    async def test_upsert_with_insertion(
         self,
-    ) -> Generator["defer.Deferred[object]", object, None]:
+    ) -> None:
         self.mock_txn.rowcount = 1
 
-        result = yield defer.ensureDeferred(
+        result = await defer.ensureDeferred(
             self.datastore.db_pool.simple_upsert(
                 table="tablename",
                 keyvalues={"columnname": "oldvalue"},
@@ -536,13 +515,12 @@ class SQLBaseStoreTestCase(unittest.TestCase):
         )
         self.assertTrue(result)
 
-    @defer.inlineCallbacks
-    def test_upsert_with_where(
+    async def test_upsert_with_where(
         self,
-    ) -> Generator["defer.Deferred[object]", object, None]:
+    ) -> None:
         self.mock_txn.rowcount = 1
 
-        result = yield defer.ensureDeferred(
+        result = await defer.ensureDeferred(
             self.datastore.db_pool.simple_upsert(
                 table="tablename",
                 keyvalues={"columnname": "oldvalue"},
@@ -557,9 +535,8 @@ class SQLBaseStoreTestCase(unittest.TestCase):
         )
         self.assertTrue(result)
 
-    @defer.inlineCallbacks
-    def test_upsert_many(self) -> Generator["defer.Deferred[object]", object, None]:
-        yield defer.ensureDeferred(
+    async def test_upsert_many(self) -> None:
+        await defer.ensureDeferred(
             self.datastore.db_pool.simple_upsert_many(
                 table="tablename",
                 key_names=["keycol1", "keycol2"],
@@ -584,11 +561,10 @@ class SQLBaseStoreTestCase(unittest.TestCase):
                 [("keyval1", "keyval2", "val5"), ("keyval3", "keyval4", "val6")],
             )
 
-    @defer.inlineCallbacks
-    def test_upsert_many_no_values(
+    async def test_upsert_many_no_values(
         self,
-    ) -> Generator["defer.Deferred[object]", object, None]:
-        yield defer.ensureDeferred(
+    ) -> None:
+        await defer.ensureDeferred(
             self.datastore.db_pool.simple_upsert_many(
                 table="tablename",
                 key_names=["columnname"],
@@ -613,15 +589,14 @@ class SQLBaseStoreTestCase(unittest.TestCase):
                 [("oldvalue",)],
             )
 
-    @defer.inlineCallbacks
-    def test_upsert_emulated_no_values_exists(
+    async def test_upsert_emulated_no_values_exists(
         self,
-    ) -> Generator["defer.Deferred[object]", object, None]:
+    ) -> None:
         self.datastore.db_pool._unsafe_to_upsert_tables.add("tablename")
 
         self.mock_txn.fetchall.return_value = [(1,)]
 
-        result = yield defer.ensureDeferred(
+        result = await defer.ensureDeferred(
             self.datastore.db_pool.simple_upsert(
                 table="tablename",
                 keyvalues={"columnname": "value"},
@@ -643,16 +618,15 @@ class SQLBaseStoreTestCase(unittest.TestCase):
             )
         self.assertFalse(result)
 
-    @defer.inlineCallbacks
-    def test_upsert_emulated_no_values_not_exists(
+    async def test_upsert_emulated_no_values_not_exists(
         self,
-    ) -> Generator["defer.Deferred[object]", object, None]:
+    ) -> None:
         self.datastore.db_pool._unsafe_to_upsert_tables.add("tablename")
 
         self.mock_txn.fetchall.return_value = []
         self.mock_txn.rowcount = 1
 
-        result = yield defer.ensureDeferred(
+        result = await defer.ensureDeferred(
             self.datastore.db_pool.simple_upsert(
                 table="tablename",
                 keyvalues={"columnname": "value"},
@@ -672,15 +646,14 @@ class SQLBaseStoreTestCase(unittest.TestCase):
         )
         self.assertTrue(result)
 
-    @defer.inlineCallbacks
-    def test_upsert_emulated_with_insertion_exists(
+    async def test_upsert_emulated_with_insertion_exists(
         self,
-    ) -> Generator["defer.Deferred[object]", object, None]:
+    ) -> None:
         self.datastore.db_pool._unsafe_to_upsert_tables.add("tablename")
 
         self.mock_txn.rowcount = 1
 
-        result = yield defer.ensureDeferred(
+        result = await defer.ensureDeferred(
             self.datastore.db_pool.simple_upsert(
                 table="tablename",
                 keyvalues={"columnname": "oldvalue"},
@@ -706,15 +679,14 @@ class SQLBaseStoreTestCase(unittest.TestCase):
             )
         self.assertTrue(result)
 
-    @defer.inlineCallbacks
-    def test_upsert_emulated_with_insertion_not_exists(
+    async def test_upsert_emulated_with_insertion_not_exists(
         self,
-    ) -> Generator["defer.Deferred[object]", object, None]:
+    ) -> None:
         self.datastore.db_pool._unsafe_to_upsert_tables.add("tablename")
 
         self.mock_txn.rowcount = 0
 
-        result = yield defer.ensureDeferred(
+        result = await defer.ensureDeferred(
             self.datastore.db_pool.simple_upsert(
                 table="tablename",
                 keyvalues={"columnname": "oldvalue"},
@@ -737,15 +709,14 @@ class SQLBaseStoreTestCase(unittest.TestCase):
         )
         self.assertTrue(result)
 
-    @defer.inlineCallbacks
-    def test_upsert_emulated_with_where(
+    async def test_upsert_emulated_with_where(
         self,
-    ) -> Generator["defer.Deferred[object]", object, None]:
+    ) -> None:
         self.datastore.db_pool._unsafe_to_upsert_tables.add("tablename")
 
         self.mock_txn.rowcount = 1
 
-        result = yield defer.ensureDeferred(
+        result = await defer.ensureDeferred(
             self.datastore.db_pool.simple_upsert(
                 table="tablename",
                 keyvalues={"columnname": "oldvalue"},
@@ -771,15 +742,14 @@ class SQLBaseStoreTestCase(unittest.TestCase):
             )
         self.assertTrue(result)
 
-    @defer.inlineCallbacks
-    def test_upsert_emulated_with_where_no_values(
+    async def test_upsert_emulated_with_where_no_values(
         self,
-    ) -> Generator["defer.Deferred[object]", object, None]:
+    ) -> None:
         self.datastore.db_pool._unsafe_to_upsert_tables.add("tablename")
 
         self.mock_txn.rowcount = 1
 
-        result = yield defer.ensureDeferred(
+        result = await defer.ensureDeferred(
             self.datastore.db_pool.simple_upsert(
                 table="tablename",
                 keyvalues={"columnname": "oldvalue"},

--- a/tests/storage/util/test_partial_state_events_tracker.py
+++ b/tests/storage/util/test_partial_state_events_tracker.py
@@ -38,18 +38,16 @@ class PartialStateEventsTrackerTestCase(TestCase):
 
         self.tracker = PartialStateEventsTracker(self.mock_store)
 
-    def test_does_not_block_for_full_state_events(self) -> None:
+    async def test_does_not_block_for_full_state_events(self) -> None:
         self._events_dict = {"event1": False, "event2": False}
 
-        self.successResultOf(
-            ensureDeferred(self.tracker.await_full_state(["event1", "event2"]))
-        )
+        await ensureDeferred(self.tracker.await_full_state(["event1", "event2"]))
 
         self.mock_store.get_partial_state_events.assert_called_once_with(
             ["event1", "event2"]
         )
 
-    def test_blocks_for_partial_state_events(self) -> None:
+    async def test_blocks_for_partial_state_events(self) -> None:
         self._events_dict = {"event1": True, "event2": False}
 
         d = ensureDeferred(self.tracker.await_full_state(["event1", "event2"]))
@@ -59,9 +57,9 @@ class PartialStateEventsTrackerTestCase(TestCase):
 
         # notifying that the event has been de-partial-stated should unblock
         self.tracker.notify_un_partial_stated("event1")
-        self.successResultOf(d)
+        await d
 
-    def test_un_partial_state_race(self) -> None:
+    async def test_un_partial_state_race(self) -> None:
         # if the event is un-partial-stated between the initial check and the
         # registration of the listener, it should not block.
         self._events_dict = {"event1": True, "event2": False}
@@ -74,11 +72,9 @@ class PartialStateEventsTrackerTestCase(TestCase):
 
         self.mock_store.get_partial_state_events.side_effect = get_partial_state_events
 
-        self.successResultOf(
-            ensureDeferred(self.tracker.await_full_state(["event1", "event2"]))
-        )
+        await ensureDeferred(self.tracker.await_full_state(["event1", "event2"]))
 
-    def test_un_partial_state_during_get_partial_state_events(self) -> None:
+    async def test_un_partial_state_during_get_partial_state_events(self) -> None:
         # we should correctly handle a call to notify_un_partial_stated during the
         # second call to get_partial_state_events.
 
@@ -97,11 +93,9 @@ class PartialStateEventsTrackerTestCase(TestCase):
 
         self.mock_store.get_partial_state_events.side_effect = get_partial_state_events1
 
-        self.successResultOf(
-            ensureDeferred(self.tracker.await_full_state(["event1", "event2"]))
-        )
+        await ensureDeferred(self.tracker.await_full_state(["event1", "event2"]))
 
-    def test_cancellation(self) -> None:
+    async def test_cancellation(self) -> None:
         self._events_dict = {"event1": True, "event2": False}
 
         d1 = ensureDeferred(self.tracker.await_full_state(["event1", "event2"]))
@@ -111,13 +105,14 @@ class PartialStateEventsTrackerTestCase(TestCase):
         self.assertNoResult(d2)
 
         d1.cancel()
-        self.assertFailure(d1, CancelledError)
+        with self.assertRaises(CancelledError):
+            await d1
 
         # d2 should still be waiting!
         self.assertNoResult(d2)
 
         self.tracker.notify_un_partial_stated("event1")
-        self.successResultOf(d2)
+        await d2
 
 
 class PartialCurrentStateTrackerTestCase(TestCase):
@@ -127,12 +122,12 @@ class PartialCurrentStateTrackerTestCase(TestCase):
 
         self.tracker = PartialCurrentStateTracker(self.mock_store)
 
-    def test_does_not_block_for_full_state_rooms(self) -> None:
+    async def test_does_not_block_for_full_state_rooms(self) -> None:
         self.mock_store.is_partial_state_room.return_value = False
 
-        self.successResultOf(ensureDeferred(self.tracker.await_full_state("room_id")))
+        await ensureDeferred(self.tracker.await_full_state("room_id"))
 
-    def test_blocks_for_partial_room_state(self) -> None:
+    async def test_blocks_for_partial_room_state(self) -> None:
         self.mock_store.is_partial_state_room.return_value = True
 
         d = ensureDeferred(self.tracker.await_full_state("room_id"))
@@ -142,9 +137,9 @@ class PartialCurrentStateTrackerTestCase(TestCase):
 
         # notifying that the room has been de-partial-stated should unblock
         self.tracker.notify_un_partial_stated("room_id")
-        self.successResultOf(d)
+        await d
 
-    def test_un_partial_state_race(self) -> None:
+    async def test_un_partial_state_race(self) -> None:
         # We should correctly handle race between awaiting the state and us
         # un-partialling the state
         async def is_partial_state_room(room_id: str) -> bool:
@@ -153,9 +148,9 @@ class PartialCurrentStateTrackerTestCase(TestCase):
 
         self.mock_store.is_partial_state_room.side_effect = is_partial_state_room
 
-        self.successResultOf(ensureDeferred(self.tracker.await_full_state("room_id")))
+        await ensureDeferred(self.tracker.await_full_state("room_id"))
 
-    def test_cancellation(self) -> None:
+    async def test_cancellation(self) -> None:
         self.mock_store.is_partial_state_room.return_value = True
 
         d1 = ensureDeferred(self.tracker.await_full_state("room_id"))
@@ -165,10 +160,11 @@ class PartialCurrentStateTrackerTestCase(TestCase):
         self.assertNoResult(d2)
 
         d1.cancel()
-        self.assertFailure(d1, CancelledError)
+        with self.assertRaises(CancelledError):
+            await d1
 
         # d2 should still be waiting!
         self.assertNoResult(d2)
 
         self.tracker.notify_un_partial_stated("room_id")
-        self.successResultOf(d2)
+        await d2

--- a/tests/test_event_auth.py
+++ b/tests/test_event_auth.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
 from collections.abc import Collection, Iterable
 from typing import Any
+from unittest import IsolatedAsyncioTestCase
 
 from parameterized import parameterized
 
@@ -25,8 +25,6 @@ from relapse.api.room_versions import EventFormatVersions, RoomVersion, RoomVers
 from relapse.events import EventBase, make_event_from_dict
 from relapse.storage.databases.main.events_worker import EventRedactBehaviour
 from relapse.types import JsonDict, get_domain_from_id
-
-from tests.test_utils import get_awaitable_result
 
 
 class _StubEventSourceStore:
@@ -59,8 +57,8 @@ class _StubEventSourceStore:
         return results
 
 
-class EventAuthTestCase(unittest.TestCase):
-    def test_rejected_auth_events(self) -> None:
+class EventAuthTestCase(IsolatedAsyncioTestCase):
+    async def test_rejected_auth_events(self) -> None:
         """
         Events that refer to rejected events in their auth events are rejected
         """
@@ -75,9 +73,7 @@ class EventAuthTestCase(unittest.TestCase):
 
         # creator should be able to send state
         event = _random_state_event(RoomVersions.V9, creator, auth_events)
-        get_awaitable_result(
-            event_auth.check_state_independent_auth_rules(event_store, event)
-        )
+        await event_auth.check_state_independent_auth_rules(event_store, event)
         event_auth.check_state_dependent_auth_rules(event, auth_events)
 
         # ... but a rejected join_rules event should cause it to be rejected
@@ -91,11 +87,9 @@ class EventAuthTestCase(unittest.TestCase):
         event_store.add_event(rejected_join_rules)
 
         with self.assertRaises(AuthError):
-            get_awaitable_result(
-                event_auth.check_state_independent_auth_rules(
-                    event_store,
-                    _random_state_event(RoomVersions.V9, creator),
-                )
+            await event_auth.check_state_independent_auth_rules(
+                event_store,
+                _random_state_event(RoomVersions.V9, creator),
             )
 
         # ... even if there is *also* a good join rules
@@ -103,14 +97,12 @@ class EventAuthTestCase(unittest.TestCase):
         event_store.add_event(rejected_join_rules)
 
         with self.assertRaises(AuthError):
-            get_awaitable_result(
-                event_auth.check_state_independent_auth_rules(
-                    event_store,
-                    _random_state_event(RoomVersions.V9, creator),
-                )
+            await event_auth.check_state_independent_auth_rules(
+                event_store,
+                _random_state_event(RoomVersions.V9, creator),
             )
 
-    def test_create_event_with_prev_events(self) -> None:
+    async def test_create_event_with_prev_events(self) -> None:
         """A create event with prev_events should be rejected
 
         https://spec.matrix.org/v1.3/rooms/v9/#authorization-rules
@@ -143,15 +135,11 @@ class EventAuthTestCase(unittest.TestCase):
 
         event_store = _StubEventSourceStore()
 
-        get_awaitable_result(
-            event_auth.check_state_independent_auth_rules(event_store, good_event)
-        )
+        await event_auth.check_state_independent_auth_rules(event_store, good_event)
         with self.assertRaises(AuthError):
-            get_awaitable_result(
-                event_auth.check_state_independent_auth_rules(event_store, bad_event)
-            )
+            await event_auth.check_state_independent_auth_rules(event_store, bad_event)
 
-    def test_duplicate_auth_events(self) -> None:
+    async def test_duplicate_auth_events(self) -> None:
         """Events with duplicate auth_events should be rejected
 
         https://spec.matrix.org/v1.3/rooms/v9/#authorization-rules
@@ -185,19 +173,13 @@ class EventAuthTestCase(unittest.TestCase):
             RoomVersions.V9, creator, [create_event, join_event2, join_event2, pl_event]
         )
 
-        get_awaitable_result(
-            event_auth.check_state_independent_auth_rules(event_store, good_event)
-        )
+        await event_auth.check_state_independent_auth_rules(event_store, good_event)
         with self.assertRaises(AuthError):
-            get_awaitable_result(
-                event_auth.check_state_independent_auth_rules(event_store, bad_event)
-            )
+            await event_auth.check_state_independent_auth_rules(event_store, bad_event)
         with self.assertRaises(AuthError):
-            get_awaitable_result(
-                event_auth.check_state_independent_auth_rules(event_store, bad_event2)
-            )
+            await event_auth.check_state_independent_auth_rules(event_store, bad_event2)
 
-    def test_unexpected_auth_events(self) -> None:
+    async def test_unexpected_auth_events(self) -> None:
         """Events with excess auth_events should be rejected
 
         https://spec.matrix.org/v1.3/rooms/v9/#authorization-rules
@@ -229,13 +211,9 @@ class EventAuthTestCase(unittest.TestCase):
             [create_event, join_event, pl_event, join_rules_event],
         )
 
-        get_awaitable_result(
-            event_auth.check_state_independent_auth_rules(event_store, good_event)
-        )
+        await event_auth.check_state_independent_auth_rules(event_store, good_event)
         with self.assertRaises(AuthError):
-            get_awaitable_result(
-                event_auth.check_state_independent_auth_rules(event_store, bad_event)
-            )
+            await event_auth.check_state_independent_auth_rules(event_store, bad_event)
 
     def test_random_users_cannot_send_state_before_first_pl(self) -> None:
         """

--- a/tests/test_mau.py
+++ b/tests/test_mau.py
@@ -217,7 +217,7 @@ class TestMauLimit(unittest.HomeserverTestCase):
         # max_mau_value should not matter
         {"max_mau_value": 1, "limit_usage_by_mau": False, "mau_stats_only": True}
     )
-    def test_tracked_but_not_limited(self) -> None:
+    async def test_tracked_but_not_limited(self) -> None:
         # Simply being able to create 2 users indicates that the
         # limit was not reached.
         token1 = self.create_user("kermit1")
@@ -229,7 +229,7 @@ class TestMauLimit(unittest.HomeserverTestCase):
         # matches what we want though
         count = self.store.get_monthly_active_count()
         self.reactor.advance(100)
-        self.assertEqual(2, self.successResultOf(count))
+        self.assertEqual(2, await count)
 
     @override_config(
         {

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -11,11 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from collections.abc import Collection, Generator, Iterable, Iterator
+from collections.abc import Collection, Iterable, Iterator
 from typing import Any, cast
 from unittest.mock import Mock
-
-from twisted.internet import defer
 
 from relapse.api.auth.internal import InternalAuth
 from relapse.api.constants import EventTypes, Membership
@@ -236,8 +234,7 @@ class StateTestCase(unittest.TestCase):
         self.state = StateHandler(hs)
         self.event_id = 0
 
-    @defer.inlineCallbacks
-    def test_branch_no_conflict(self) -> Generator[defer.Deferred, Any, None]:
+    async def test_branch_no_conflict(self) -> None:
         graph = Graph(
             nodes={
                 "START": DictObj(
@@ -256,26 +253,22 @@ class StateTestCase(unittest.TestCase):
         context_store: dict[str, EventContext] = {}
 
         for event in graph.walk():
-            context = yield defer.ensureDeferred(
-                self.state.compute_event_context(event)
-            )
+            context = await self.state.compute_event_context(event)
             self.dummy_store.register_event_context(event, context)
             context_store[event.event_id] = context
 
         ctx_c = context_store["C"]
         ctx_d = context_store["D"]
 
-        prev_state_ids: StateMap[str]
-        prev_state_ids = yield defer.ensureDeferred(ctx_d.get_prev_state_ids())
+        prev_state_ids = await ctx_d.get_prev_state_ids()
         self.assertEqual(2, len(prev_state_ids))
 
         self.assertEqual(ctx_c.state_group, ctx_d.state_group_before_event)
         self.assertEqual(ctx_d.state_group_before_event, ctx_d.state_group)
 
-    @defer.inlineCallbacks
-    def test_branch_basic_conflict(
+    async def test_branch_basic_conflict(
         self,
-    ) -> Generator["defer.Deferred[object]", Any, None]:
+    ) -> None:
         graph = Graph(
             nodes={
                 "START": DictObj(
@@ -303,9 +296,7 @@ class StateTestCase(unittest.TestCase):
         context_store: dict[str, EventContext] = {}
 
         for event in graph.walk():
-            context = yield defer.ensureDeferred(
-                self.state.compute_event_context(event)
-            )
+            context = await self.state.compute_event_context(event)
             self.dummy_store.register_event_context(event, context)
             context_store[event.event_id] = context
 
@@ -314,17 +305,15 @@ class StateTestCase(unittest.TestCase):
         ctx_c = context_store["C"]
         ctx_d = context_store["D"]
 
-        prev_state_ids: StateMap[str]
-        prev_state_ids = yield defer.ensureDeferred(ctx_d.get_prev_state_ids())
+        prev_state_ids = await ctx_d.get_prev_state_ids()
         self.assertSetEqual({"START", "A", "C"}, set(prev_state_ids.values()))
 
         self.assertEqual(ctx_c.state_group, ctx_d.state_group_before_event)
         self.assertEqual(ctx_d.state_group_before_event, ctx_d.state_group)
 
-    @defer.inlineCallbacks
-    def test_branch_have_banned_conflict(
+    async def test_branch_have_banned_conflict(
         self,
-    ) -> Generator["defer.Deferred[object]", Any, None]:
+    ) -> None:
         graph = Graph(
             nodes={
                 "START": DictObj(
@@ -364,9 +353,7 @@ class StateTestCase(unittest.TestCase):
         context_store: dict[str, EventContext] = {}
 
         for event in graph.walk():
-            context = yield defer.ensureDeferred(
-                self.state.compute_event_context(event)
-            )
+            context = await self.state.compute_event_context(event)
             self.dummy_store.register_event_context(event, context)
             context_store[event.event_id] = context
 
@@ -376,16 +363,14 @@ class StateTestCase(unittest.TestCase):
         ctx_c = context_store["C"]
         ctx_e = context_store["E"]
 
-        prev_state_ids: StateMap[str]
-        prev_state_ids = yield defer.ensureDeferred(ctx_e.get_prev_state_ids())
+        prev_state_ids = await ctx_e.get_prev_state_ids()
         self.assertSetEqual({"START", "A", "B", "C"}, set(prev_state_ids.values()))
         self.assertEqual(ctx_c.state_group, ctx_e.state_group_before_event)
         self.assertEqual(ctx_e.state_group_before_event, ctx_e.state_group)
 
-    @defer.inlineCallbacks
-    def test_branch_have_perms_conflict(
+    async def test_branch_have_perms_conflict(
         self,
-    ) -> Generator["defer.Deferred[object]", Any, None]:
+    ) -> None:
         userid1 = "@user_id:example.com"
         userid2 = "@user_id2:example.com"
 
@@ -442,9 +427,7 @@ class StateTestCase(unittest.TestCase):
         context_store: dict[str, EventContext] = {}
 
         for event in graph.walk():
-            context = yield defer.ensureDeferred(
-                self.state.compute_event_context(event)
-            )
+            context = await self.state.compute_event_context(event)
             self.dummy_store.register_event_context(event, context)
             context_store[event.event_id] = context
 
@@ -454,8 +437,7 @@ class StateTestCase(unittest.TestCase):
         ctx_b = context_store["B"]
         ctx_d = context_store["D"]
 
-        prev_state_ids: StateMap[str]
-        prev_state_ids = yield defer.ensureDeferred(ctx_d.get_prev_state_ids())
+        prev_state_ids = await ctx_d.get_prev_state_ids()
         self.assertSetEqual({"A1", "A2", "A3", "A5", "B"}, set(prev_state_ids.values()))
 
         self.assertEqual(ctx_b.state_group, ctx_d.state_group_before_event)
@@ -475,10 +457,9 @@ class StateTestCase(unittest.TestCase):
         for n in nodes:
             _get_depth(n)
 
-    @defer.inlineCallbacks
-    def test_annotate_with_old_message(
+    async def test_annotate_with_old_message(
         self,
-    ) -> Generator["defer.Deferred[object]", Any, None]:
+    ) -> None:
         event = create_event(type="test_message", name="event")
 
         old_state = [
@@ -488,22 +469,19 @@ class StateTestCase(unittest.TestCase):
         ]
 
         context: EventContext
-        context = yield defer.ensureDeferred(
-            self.state.compute_event_context(
-                event,
-                state_ids_before_event={
-                    (e.type, e.state_key): e.event_id for e in old_state
-                },
-                partial_state=False,
-            )
+        context = await self.state.compute_event_context(
+            event,
+            state_ids_before_event={
+                (e.type, e.state_key): e.event_id for e in old_state
+            },
+            partial_state=False,
         )
 
-        prev_state_ids: StateMap[str]
-        prev_state_ids = yield defer.ensureDeferred(context.get_prev_state_ids())
+        prev_state_ids = await context.get_prev_state_ids()
         self.assertCountEqual((e.event_id for e in old_state), prev_state_ids.values())
 
-        current_state_ids: StateMap[str]
-        current_state_ids = yield defer.ensureDeferred(context.get_current_state_ids())
+        current_state_ids = await context.get_current_state_ids()
+        assert current_state_ids is not None
         self.assertCountEqual(
             (e.event_id for e in old_state), current_state_ids.values()
         )
@@ -511,10 +489,9 @@ class StateTestCase(unittest.TestCase):
         self.assertIsNotNone(context.state_group_before_event)
         self.assertEqual(context.state_group_before_event, context.state_group)
 
-    @defer.inlineCallbacks
-    def test_annotate_with_old_state(
+    async def test_annotate_with_old_state(
         self,
-    ) -> Generator["defer.Deferred[object]", Any, None]:
+    ) -> None:
         event = create_event(type="state", state_key="", name="event")
 
         old_state = [
@@ -524,22 +501,19 @@ class StateTestCase(unittest.TestCase):
         ]
 
         context: EventContext
-        context = yield defer.ensureDeferred(
-            self.state.compute_event_context(
-                event,
-                state_ids_before_event={
-                    (e.type, e.state_key): e.event_id for e in old_state
-                },
-                partial_state=False,
-            )
+        context = await self.state.compute_event_context(
+            event,
+            state_ids_before_event={
+                (e.type, e.state_key): e.event_id for e in old_state
+            },
+            partial_state=False,
         )
 
-        prev_state_ids: StateMap[str]
-        prev_state_ids = yield defer.ensureDeferred(context.get_prev_state_ids())
+        prev_state_ids = await context.get_prev_state_ids()
         self.assertCountEqual((e.event_id for e in old_state), prev_state_ids.values())
 
-        current_state_ids: StateMap[str]
-        current_state_ids = yield defer.ensureDeferred(context.get_current_state_ids())
+        current_state_ids = await context.get_current_state_ids()
+        assert current_state_ids is not None
         self.assertCountEqual(
             (e.event_id for e in old_state + [event]), current_state_ids.values()
         )
@@ -554,10 +528,9 @@ class StateTestCase(unittest.TestCase):
         )
         self.assertNotEqual(context.state_group_before_event, context.state_group)
 
-    @defer.inlineCallbacks
-    def test_trivial_annotate_message(
+    async def test_trivial_annotate_message(
         self,
-    ) -> Generator["defer.Deferred[object]", Any, None]:
+    ) -> None:
         prev_event_id = "prev_event_id"
         event = create_event(
             type="test_message", name="event2", prev_events=[(prev_event_id, {})]
@@ -569,33 +542,29 @@ class StateTestCase(unittest.TestCase):
             create_event(type="test2", state_key=""),
         ]
 
-        group_name = yield defer.ensureDeferred(
-            self.dummy_store.store_state_group(
-                prev_event_id,
-                event.room_id,
-                None,
-                None,
-                {(e.type, e.state_key): e.event_id for e in old_state},
-            )
+        group_name = await self.dummy_store.store_state_group(
+            prev_event_id,
+            event.room_id,
+            None,
+            None,
+            {(e.type, e.state_key): e.event_id for e in old_state},
         )
         self.dummy_store.register_event_id_state_group(prev_event_id, group_name)
 
         context: EventContext
-        context = yield defer.ensureDeferred(self.state.compute_event_context(event))
+        context = await self.state.compute_event_context(event)
 
-        current_state_ids: StateMap[str]
-        current_state_ids = yield defer.ensureDeferred(context.get_current_state_ids())
-
+        current_state_ids = await context.get_current_state_ids()
+        assert current_state_ids is not None
         self.assertEqual(
             {e.event_id for e in old_state}, set(current_state_ids.values())
         )
 
         self.assertEqual(group_name, context.state_group)
 
-    @defer.inlineCallbacks
-    def test_trivial_annotate_state(
+    async def test_trivial_annotate_state(
         self,
-    ) -> Generator["defer.Deferred[object]", Any, None]:
+    ) -> None:
         prev_event_id = "prev_event_id"
         event = create_event(
             type="state", state_key="", name="event2", prev_events=[(prev_event_id, {})]
@@ -607,31 +576,25 @@ class StateTestCase(unittest.TestCase):
             create_event(type="test2", state_key=""),
         ]
 
-        group_name = yield defer.ensureDeferred(
-            self.dummy_store.store_state_group(
-                prev_event_id,
-                event.room_id,
-                None,
-                None,
-                {(e.type, e.state_key): e.event_id for e in old_state},
-            )
+        group_name = await self.dummy_store.store_state_group(
+            prev_event_id,
+            event.room_id,
+            None,
+            None,
+            {(e.type, e.state_key): e.event_id for e in old_state},
         )
         self.dummy_store.register_event_id_state_group(prev_event_id, group_name)
 
         context: EventContext
-        context = yield defer.ensureDeferred(self.state.compute_event_context(event))
+        context = await self.state.compute_event_context(event)
 
-        prev_state_ids: StateMap[str]
-        prev_state_ids = yield defer.ensureDeferred(context.get_prev_state_ids())
+        prev_state_ids = await context.get_prev_state_ids()
 
         self.assertEqual({e.event_id for e in old_state}, set(prev_state_ids.values()))
 
         self.assertIsNotNone(context.state_group)
 
-    @defer.inlineCallbacks
-    def test_resolve_message_conflict(
-        self,
-    ) -> Generator["defer.Deferred[Any]", Any, None]:
+    async def test_resolve_message_conflict(self) -> None:
         prev_event_id1 = "event_id1"
         prev_event_id2 = "event_id2"
         event = create_event(
@@ -659,22 +622,17 @@ class StateTestCase(unittest.TestCase):
         self.dummy_store.register_events(old_state_1)
         self.dummy_store.register_events(old_state_2)
 
-        context: EventContext
-        context = yield self._get_context(
+        context = await self._get_context(
             event, prev_event_id1, old_state_1, prev_event_id2, old_state_2
         )
 
-        current_state_ids: StateMap[str]
-        current_state_ids = yield defer.ensureDeferred(context.get_current_state_ids())
-
+        current_state_ids = await context.get_current_state_ids()
+        assert current_state_ids is not None
         self.assertEqual(len(current_state_ids), 6)
 
         self.assertIsNotNone(context.state_group)
 
-    @defer.inlineCallbacks
-    def test_resolve_state_conflict(
-        self,
-    ) -> Generator["defer.Deferred[Any]", Any, None]:
+    async def test_resolve_state_conflict(self) -> None:
         prev_event_id1 = "event_id1"
         prev_event_id2 = "event_id2"
         event = create_event(
@@ -706,21 +664,17 @@ class StateTestCase(unittest.TestCase):
         self.dummy_store.get_events = store.get_events  # type: ignore[method-assign]
 
         context: EventContext
-        context = yield self._get_context(
+        context = await self._get_context(
             event, prev_event_id1, old_state_1, prev_event_id2, old_state_2
         )
 
-        current_state_ids: StateMap[str]
-        current_state_ids = yield defer.ensureDeferred(context.get_current_state_ids())
-
+        current_state_ids = await context.get_current_state_ids()
+        assert current_state_ids is not None
         self.assertEqual(len(current_state_ids), 6)
 
         self.assertIsNotNone(context.state_group)
 
-    @defer.inlineCallbacks
-    def test_standard_depth_conflict(
-        self,
-    ) -> Generator["defer.Deferred[Any]", Any, None]:
+    async def test_standard_depth_conflict(self) -> None:
         prev_event_id1 = "event_id1"
         prev_event_id2 = "event_id2"
         event = create_event(
@@ -765,13 +719,12 @@ class StateTestCase(unittest.TestCase):
         self.dummy_store.get_events = store.get_events  # type: ignore[method-assign]
 
         context: EventContext
-        context = yield self._get_context(
+        context = await self._get_context(
             event, prev_event_id1, old_state_1, prev_event_id2, old_state_2
         )
 
-        current_state_ids: StateMap[str]
-        current_state_ids = yield defer.ensureDeferred(context.get_current_state_ids())
-
+        current_state_ids = await context.get_current_state_ids()
+        assert current_state_ids is not None
         self.assertEqual(old_state_2[3].event_id, current_state_ids[("test1", "1")])
 
         # Reverse the depth to make sure we are actually using the depths
@@ -794,48 +747,43 @@ class StateTestCase(unittest.TestCase):
         store.register_events(old_state_1)
         store.register_events(old_state_2)
 
-        context = yield self._get_context(
+        context = await self._get_context(
             event, prev_event_id1, old_state_1, prev_event_id2, old_state_2
         )
 
-        current_state_ids = yield defer.ensureDeferred(context.get_current_state_ids())
-
+        current_state_ids = await context.get_current_state_ids()
+        assert current_state_ids is not None
         self.assertEqual(old_state_1[3].event_id, current_state_ids[("test1", "1")])
 
-    @defer.inlineCallbacks
-    def _get_context(
+    async def _get_context(
         self,
         event: EventBase,
         prev_event_id_1: str,
         old_state_1: Collection[EventBase],
         prev_event_id_2: str,
         old_state_2: Collection[EventBase],
-    ) -> Generator["defer.Deferred[object]", Any, EventContext]:
+    ) -> EventContext:
         sg1: int
-        sg1 = yield defer.ensureDeferred(
-            self.dummy_store.store_state_group(
-                prev_event_id_1,
-                event.room_id,
-                None,
-                None,
-                {(e.type, e.state_key): e.event_id for e in old_state_1},
-            )
+        sg1 = await self.dummy_store.store_state_group(
+            prev_event_id_1,
+            event.room_id,
+            None,
+            None,
+            {(e.type, e.state_key): e.event_id for e in old_state_1},
         )
         self.dummy_store.register_event_id_state_group(prev_event_id_1, sg1)
 
         sg2: int
-        sg2 = yield defer.ensureDeferred(
-            self.dummy_store.store_state_group(
-                prev_event_id_2,
-                event.room_id,
-                None,
-                None,
-                {(e.type, e.state_key): e.event_id for e in old_state_2},
-            )
+        sg2 = await self.dummy_store.store_state_group(
+            prev_event_id_2,
+            event.room_id,
+            None,
+            None,
+            {(e.type, e.state_key): e.event_id for e in old_state_2},
         )
         self.dummy_store.register_event_id_state_group(prev_event_id_2, sg2)
 
-        result = yield defer.ensureDeferred(self.state.compute_event_context(event))
+        result = await self.state.compute_event_context(event)
         return result
 
     def test_make_state_cache_entry(self) -> None:

--- a/tests/test_utils/__init__.py
+++ b/tests/test_utils/__init__.py
@@ -20,7 +20,7 @@ import json
 import sys
 import warnings
 from binascii import unhexlify
-from collections.abc import Awaitable, Callable
+from collections.abc import Callable
 from typing import TYPE_CHECKING, TypeVar
 
 import attr
@@ -39,22 +39,6 @@ if TYPE_CHECKING:
     from sys import UnraisableHookArgs
 
 TV = TypeVar("TV")
-
-
-def get_awaitable_result(awaitable: Awaitable[TV]) -> TV:
-    """Get the result from an Awaitable which should have completed
-
-    Asserts that the given awaitable has a result ready, and returns its value
-    """
-    i = awaitable.__await__()
-    try:
-        next(i)
-    except StopIteration as e:
-        # awaitable returned a result
-        return e.value
-
-    # if next didn't raise, the awaitable hasn't completed.
-    raise Exception("awaitable has not yet completed")
 
 
 def setup_awaitable_errors() -> Callable[[], None]:

--- a/tests/util/caches/test_cached_call.py
+++ b/tests/util/caches/test_cached_call.py
@@ -19,12 +19,11 @@ from twisted.internet.defer import Deferred
 
 from relapse.util.caches.cached_call import CachedCall, RetryOnExceptionCachedCall
 
-from tests.test_utils import get_awaitable_result
 from tests.unittest import TestCase
 
 
 class CachedCallTestCase(TestCase):
-    def test_get(self) -> None:
+    async def test_get(self) -> None:
         """
         Happy-path test case: makes a couple of calls and makes sure they behave
         correctly
@@ -61,16 +60,16 @@ class CachedCallTestCase(TestCase):
         # allow the deferred to complete, which should complete both the pending results
         d.callback(123)
         self.assertEqual(completed_results, [123, 123])
-        self.successResultOf(r1)
-        self.successResultOf(r2)
+        await r1
+        await r2
 
         # another call to the getter should complete immediately
         slow_call.reset_mock()
-        r3 = get_awaitable_result(cached_call.get())
+        r3 = await cached_call.get()
         self.assertEqual(r3, 123)
         slow_call.assert_not_called()
 
-    def test_fast_call(self) -> None:
+    async def test_fast_call(self) -> None:
         """
         Test the behaviour when the underlying function completes immediately
         """
@@ -85,15 +84,15 @@ class CachedCallTestCase(TestCase):
         fast_call.assert_not_called()
 
         # run the call a couple of times, which should complete immediately
-        self.assertEqual(get_awaitable_result(cached_call.get()), 12)
-        self.assertEqual(get_awaitable_result(cached_call.get()), 12)
+        self.assertEqual(await cached_call.get(), 12)
+        self.assertEqual(await cached_call.get(), 12)
 
         # the mock should have been called once
         fast_call.assert_called_once_with()
 
 
 class RetryOnExceptionCachedCallTestCase(TestCase):
-    def test_get(self) -> None:
+    async def test_get(self) -> None:
         # set up the RetryOnExceptionCachedCall around a function which will fail
         # (after a while)
         d: Deferred[int] = Deferred()
@@ -152,10 +151,10 @@ class RetryOnExceptionCachedCallTestCase(TestCase):
 
         # let that call complete, and check the results
         d.callback(123)
-        self.assertEqual(self.successResultOf(r3), 123)
-        self.assertEqual(self.successResultOf(r4), 123)
+        self.assertEqual(await r3, 123)
+        self.assertEqual(await r4, 123)
 
         # and now more calls to the getter should complete immediately
         slow_call.reset_mock()
-        self.assertEqual(get_awaitable_result(cached_call.get()), 123)
+        self.assertEqual(await cached_call.get(), 123)
         slow_call.assert_not_called()

--- a/tests/util/caches/test_deferred_cache.py
+++ b/tests/util/caches/test_deferred_cache.py
@@ -27,13 +27,13 @@ class DeferredCacheTestCase(TestCase):
         with self.assertRaises(KeyError):
             cache.get("foo")
 
-    def test_hit(self) -> None:
+    async def test_hit(self) -> None:
         cache: DeferredCache[str, int] = DeferredCache("test")
         cache.prefill("foo", 123)
 
-        self.assertEqual(self.successResultOf(cache.get("foo")), 123)
+        self.assertEqual(await cache.get("foo"), 123)
 
-    def test_hit_deferred(self) -> None:
+    async def test_hit_deferred(self) -> None:
         cache: DeferredCache[str, int] = DeferredCache("test")
         origin_d: defer.Deferred[int] = defer.Deferred()
         set_d = cache.set("k1", origin_d)
@@ -51,11 +51,11 @@ class DeferredCacheTestCase(TestCase):
 
         # now fire off all the deferreds
         origin_d.callback(99)
-        self.assertEqual(self.successResultOf(origin_d), 99)
-        self.assertEqual(self.successResultOf(set_d), 99)
-        self.assertEqual(self.successResultOf(get_d), 99)
+        self.assertEqual(await origin_d, 99)
+        self.assertEqual(await set_d, 99)
+        self.assertEqual(await get_d, 99)
 
-    def test_callbacks(self) -> None:
+    async def test_callbacks(self) -> None:
         """Invalidation callbacks are called at the right time"""
         cache: DeferredCache[str, int] = DeferredCache("test")
         callbacks = set()
@@ -77,8 +77,8 @@ class DeferredCacheTestCase(TestCase):
 
         # now fire off all the deferreds
         origin_d.callback(20)
-        self.assertEqual(self.successResultOf(set_d), 20)
-        self.assertEqual(self.successResultOf(get_d), 20)
+        self.assertEqual(await set_d, 20)
+        self.assertEqual(await get_d, 20)
 
         # now the original invalidation callback should have been called, but none of
         # the others
@@ -89,7 +89,7 @@ class DeferredCacheTestCase(TestCase):
         cache.prefill("k1", 30)
         self.assertEqual(callbacks, {"set", "get"})
 
-    def test_set_fail(self) -> None:
+    async def test_set_fail(self) -> None:
         cache: DeferredCache[str, int] = DeferredCache("test")
         callbacks = set()
 
@@ -109,8 +109,12 @@ class DeferredCacheTestCase(TestCase):
         # oh noes! fails!
         e = Exception("oops")
         origin_d.errback(e)
-        self.assertIs(self.failureResultOf(set_d, Exception).value, e)
-        self.assertIs(self.failureResultOf(get_d, Exception).value, e)
+        with self.assertRaises(Exception) as exc:
+            await set_d
+        self.assertIs(exc.exception, e)
+        with self.assertRaises(Exception) as exc:
+            await get_d
+        self.assertIs(exc.exception, e)
 
         # the callbacks for the failed requests should have been called.
         # I'm not sure if this is deliberate or not.
@@ -119,7 +123,7 @@ class DeferredCacheTestCase(TestCase):
 
         # the old value should still be returned now?
         get_d2 = cache.get("k1", callback=lambda: callbacks.add("get2"))
-        self.assertEqual(self.successResultOf(get_d2), 10)
+        self.assertEqual(await get_d2, 10)
 
         # replacing the value now should run the callbacks for those requests
         # which got the original result
@@ -150,7 +154,7 @@ class DeferredCacheTestCase(TestCase):
         with self.assertRaises(KeyError):
             cache.get(("foo",))
 
-    def test_invalidate_all(self) -> None:
+    async def test_invalidate_all(self) -> None:
         cache: DeferredCache[str, str] = DeferredCache("testcache")
 
         callback_record = [False, False]
@@ -173,7 +177,7 @@ class DeferredCacheTestCase(TestCase):
         d2.callback("result2")
 
         # now the cache will return a completed deferred
-        self.assertEqual(self.successResultOf(cache.get("key2")), "result2")
+        self.assertEqual(await cache.get("key2"), "result2")
 
         # now do the invalidation
         cache.invalidate_all()

--- a/tests/util/caches/test_descriptors.py
+++ b/tests/util/caches/test_descriptors.py
@@ -184,7 +184,7 @@ class DescriptorTestCase(unittest.TestCase):
         self.assertEqual(r, "fish")
         obj.mock.assert_not_called()
 
-    def test_cache_with_sync_exception(self) -> None:
+    async def test_cache_with_sync_exception(self) -> None:
         """If the wrapped function throws synchronously, things should continue to work"""
 
         class Cls:
@@ -196,14 +196,16 @@ class DescriptorTestCase(unittest.TestCase):
 
         # this should fail immediately
         d = obj.fn(1)
-        self.failureResultOf(d, RelapseError)
+        with self.assertRaises(RelapseError):
+            await d
 
         # ... leaving the cache empty
         self.assertEqual(len(obj.fn.cache.cache), 0)
 
         # and a second call should result in a second exception
         d = obj.fn(1)
-        self.failureResultOf(d, RelapseError)
+        with self.assertRaises(RelapseError):
+            await d
 
     async def test_cache_with_async_exception(self) -> None:
         """The wrapped function returns a failure"""
@@ -242,8 +244,13 @@ class DescriptorTestCase(unittest.TestCase):
         origin_d.errback(e)
 
         # ... which should cause the lookups to fail similarly
-        self.assertIs(self.failureResultOf(d1, Exception).value, e)
-        self.assertIs(self.failureResultOf(d2, Exception).value, e)
+        with self.assertRaises(Exception) as exc:
+            await d1
+        self.assertIs(exc.exception, e)
+
+        with self.assertRaises(Exception) as exc:
+            await d2
+        self.assertIs(exc.exception, e)
 
         # ... and the callbacks to have been, uh, called.
         self.assertEqual(callbacks, {"d1", "d2"})
@@ -410,7 +417,7 @@ class DescriptorTestCase(unittest.TestCase):
         self.assertEqual(r.result, ("chips",))
         obj.mock.assert_not_called()
 
-    def test_cache_iterable_with_sync_exception(self) -> None:
+    async def test_cache_iterable_with_sync_exception(self) -> None:
         """If the wrapped function throws synchronously, things should continue to work"""
 
         class Cls:
@@ -422,14 +429,16 @@ class DescriptorTestCase(unittest.TestCase):
 
         # this should fail immediately
         d = obj.fn(1)
-        self.failureResultOf(d, RelapseError)
+        with self.assertRaises(RelapseError):
+            await d
 
         # ... leaving the cache empty
         self.assertEqual(len(obj.fn.cache.cache), 0)
 
         # and a second call should result in a second exception
         d = obj.fn(1)
-        self.failureResultOf(d, RelapseError)
+        with self.assertRaises(RelapseError):
+            await d
 
     async def test_invalidate_cascade(self) -> None:
         """Invalidations should cascade up through cache contexts"""
@@ -456,7 +465,7 @@ class DescriptorTestCase(unittest.TestCase):
         obj.invalidate()
         top_invalidate.assert_called_once()
 
-    def test_cancel(self) -> None:
+    async def test_cancel(self) -> None:
         """Test that cancelling a lookup does not cancel other lookups"""
         complete_lookup: Deferred[None] = Deferred()
 
@@ -478,7 +487,8 @@ class DescriptorTestCase(unittest.TestCase):
 
         # `d2` should complete normally.
         complete_lookup.callback(None)
-        self.failureResultOf(d1, CancelledError)
+        with self.assertRaises(CancelledError):
+            await d1
         self.assertEqual(d2.result, "123")
 
     async def test_cancel_logcontexts(self) -> None:
@@ -892,7 +902,7 @@ class CachedListDescriptorTestCase(unittest.TestCase):
         invalidate0.assert_called_once()
         invalidate1.assert_called_once()
 
-    def test_cancel(self) -> None:
+    async def test_cancel(self) -> None:
         """Test that cancelling a lookup does not cancel other lookups"""
         complete_lookup: Deferred[None] = Deferred()
 
@@ -917,7 +927,8 @@ class CachedListDescriptorTestCase(unittest.TestCase):
 
         # `d2` should complete normally.
         complete_lookup.callback(None)
-        self.failureResultOf(d1, CancelledError)
+        with self.assertRaises(CancelledError):
+            await d1
         self.assertEqual(d2.result, {123: "123", 456: "456", 789: "789"})
 
     async def test_cancel_logcontexts(self) -> None:

--- a/tests/util/caches/test_descriptors.py
+++ b/tests/util/caches/test_descriptors.py
@@ -33,7 +33,6 @@ from relapse.util.caches import descriptors
 from relapse.util.caches.descriptors import _CacheContext, cached, cachedList
 
 from tests import unittest
-from tests.test_utils import get_awaitable_result
 
 logger = logging.getLogger(__name__)
 
@@ -432,7 +431,7 @@ class DescriptorTestCase(unittest.TestCase):
         d = obj.fn(1)
         self.failureResultOf(d, RelapseError)
 
-    def test_invalidate_cascade(self) -> None:
+    async def test_invalidate_cascade(self) -> None:
         """Invalidations should cascade up through cache contexts"""
 
         class Cls:
@@ -452,7 +451,7 @@ class DescriptorTestCase(unittest.TestCase):
         obj = Cls()
 
         top_invalidate = mock.Mock()
-        r = get_awaitable_result(obj.func1("k1", on_invalidate=top_invalidate))
+        r = await obj.func1("k1", on_invalidate=top_invalidate)
         self.assertEqual(r, 42)
         obj.invalidate()
         top_invalidate.assert_called_once()

--- a/tests/util/caches/test_descriptors.py
+++ b/tests/util/caches/test_descriptors.py
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
-from collections.abc import Generator, Iterable, Mapping
-from typing import Any, NoReturn, cast
+from collections.abc import Iterable, Mapping
+from typing import NoReturn, cast
 from unittest import mock
 
 from twisted.internet import defer, reactor
@@ -38,15 +38,14 @@ from tests.test_utils import get_awaitable_result
 logger = logging.getLogger(__name__)
 
 
-def run_on_reactor() -> "Deferred[int]":
+def run_on_reactor() -> Deferred[int]:
     d: Deferred[int] = Deferred()
     cast(IReactorTime, reactor).callLater(0, d.callback, 0)
     return make_deferred_yieldable(d)
 
 
 class DescriptorTestCase(unittest.TestCase):
-    @defer.inlineCallbacks
-    def test_cache(self) -> Generator["Deferred[Any]", object, None]:
+    async def test_cache(self) -> None:
         class Cls:
             def __init__(self) -> None:
                 self.mock = mock.Mock()
@@ -58,27 +57,26 @@ class DescriptorTestCase(unittest.TestCase):
         obj = Cls()
 
         obj.mock.return_value = "fish"
-        r = yield obj.fn(1, 2)
+        r = await obj.fn(1, 2)
         self.assertEqual(r, "fish")
         obj.mock.assert_called_once_with(1, 2)
         obj.mock.reset_mock()
 
         # a call with different params should call the mock again
         obj.mock.return_value = "chips"
-        r = yield obj.fn(1, 3)
+        r = await obj.fn(1, 3)
         self.assertEqual(r, "chips")
         obj.mock.assert_called_once_with(1, 3)
         obj.mock.reset_mock()
 
         # the two values should now be cached
-        r = yield obj.fn(1, 2)
+        r = await obj.fn(1, 2)
         self.assertEqual(r, "fish")
-        r = yield obj.fn(1, 3)
+        r = await obj.fn(1, 3)
         self.assertEqual(r, "chips")
         obj.mock.assert_not_called()
 
-    @defer.inlineCallbacks
-    def test_cache_num_args(self) -> Generator["Deferred[Any]", object, None]:
+    async def test_cache_num_args(self) -> None:
         """Only the first num_args arguments should matter to the cache"""
 
         class Cls:
@@ -91,28 +89,27 @@ class DescriptorTestCase(unittest.TestCase):
 
         obj = Cls()
         obj.mock.return_value = "fish"
-        r = yield obj.fn(1, 2)
+        r = await obj.fn(1, 2)
         self.assertEqual(r, "fish")
         obj.mock.assert_called_once_with(1, 2)
         obj.mock.reset_mock()
 
         # a call with different params should call the mock again
         obj.mock.return_value = "chips"
-        r = yield obj.fn(2, 3)
+        r = await obj.fn(2, 3)
         self.assertEqual(r, "chips")
         obj.mock.assert_called_once_with(2, 3)
         obj.mock.reset_mock()
 
         # the two values should now be cached; we should be able to vary
         # the second argument and still get the cached result.
-        r = yield obj.fn(1, 4)
+        r = await obj.fn(1, 4)
         self.assertEqual(r, "fish")
-        r = yield obj.fn(2, 5)
+        r = await obj.fn(2, 5)
         self.assertEqual(r, "chips")
         obj.mock.assert_not_called()
 
-    @defer.inlineCallbacks
-    def test_cache_uncached_args(self) -> Generator["Deferred[Any]", object, None]:
+    async def test_cache_uncached_args(self) -> None:
         """
         Only the arguments not named in uncached_args should matter to the cache
 
@@ -132,28 +129,27 @@ class DescriptorTestCase(unittest.TestCase):
 
         obj = Cls()
         obj.mock.return_value = "fish"
-        r = yield obj.fn(1, 2, 3)
+        r = await obj.fn(1, 2, 3)
         self.assertEqual(r, "fish")
         obj.mock.assert_called_once_with(1, 2, 3)
         obj.mock.reset_mock()
 
         # a call with different params should call the mock again
         obj.mock.return_value = "chips"
-        r = yield obj.fn(2, 3, 4)
+        r = await obj.fn(2, 3, 4)
         self.assertEqual(r, "chips")
         obj.mock.assert_called_once_with(2, 3, 4)
         obj.mock.reset_mock()
 
         # the two values should now be cached; we should be able to vary
         # the second argument and still get the cached result.
-        r = yield obj.fn(1, 4, 3)
+        r = await obj.fn(1, 4, 3)
         self.assertEqual(r, "fish")
-        r = yield obj.fn(2, 5, 4)
+        r = await obj.fn(2, 5, 4)
         self.assertEqual(r, "chips")
         obj.mock.assert_not_called()
 
-    @defer.inlineCallbacks
-    def test_cache_kwargs(self) -> Generator["Deferred[Any]", object, None]:
+    async def test_cache_kwargs(self) -> None:
         """Test that keyword arguments are treated properly"""
 
         class Cls:
@@ -166,26 +162,26 @@ class DescriptorTestCase(unittest.TestCase):
 
         obj = Cls()
         obj.mock.return_value = "fish"
-        r = yield obj.fn(1, kwarg1=2)
+        r = await obj.fn(1, kwarg1=2)
         self.assertEqual(r, "fish")
         obj.mock.assert_called_once_with(1, kwarg1=2)
         obj.mock.reset_mock()
 
         # a call with different params should call the mock again
         obj.mock.return_value = "chips"
-        r = yield obj.fn(1, kwarg1=3)
+        r = await obj.fn(1, kwarg1=3)
         self.assertEqual(r, "chips")
         obj.mock.assert_called_once_with(1, kwarg1=3)
         obj.mock.reset_mock()
 
         # the values should now be cached.
-        r = yield obj.fn(1, kwarg1=2)
+        r = await obj.fn(1, kwarg1=2)
         self.assertEqual(r, "fish")
         # We should be able to not provide kwarg1 and get the cached value back.
-        r = yield obj.fn(1)
+        r = await obj.fn(1)
         self.assertEqual(r, "fish")
         # Keyword arguments can be in any order.
-        r = yield obj.fn(kwarg1=2, arg1=1)
+        r = await obj.fn(kwarg1=2, arg1=1)
         self.assertEqual(r, "fish")
         obj.mock.assert_not_called()
 
@@ -210,7 +206,7 @@ class DescriptorTestCase(unittest.TestCase):
         d = obj.fn(1)
         self.failureResultOf(d, RelapseError)
 
-    def test_cache_with_async_exception(self) -> None:
+    async def test_cache_with_async_exception(self) -> None:
         """The wrapped function returns a failure"""
 
         class Cls:
@@ -259,10 +255,10 @@ class DescriptorTestCase(unittest.TestCase):
         # and a second call should work as normal
         obj.result = defer.succeed(100)
         d3 = obj.fn(1)
-        self.assertEqual(self.successResultOf(d3), 100)
+        self.assertEqual(await d3, 100)
         self.assertEqual(obj.call_count, 2)
 
-    def test_cache_logcontexts(self) -> Deferred:
+    async def test_cache_logcontexts(self) -> None:
         """Check that logcontexts are set and restored correctly when
         using the cache."""
 
@@ -270,21 +266,19 @@ class DescriptorTestCase(unittest.TestCase):
 
         class Cls:
             @descriptors.cached()
-            def fn(self, arg1: int) -> "Deferred[int]":
-                @defer.inlineCallbacks
-                def inner_fn() -> Generator["Deferred[object]", object, int]:
+            async def fn(self, arg1: int) -> int:
+                async def inner_fn() -> int:
                     with PreserveLoggingContext():
-                        yield complete_lookup
+                        await complete_lookup
                     return 1
 
-                return inner_fn()
+                return await inner_fn()
 
-        @defer.inlineCallbacks
-        def do_lookup() -> Generator["Deferred[Any]", object, int]:
+        async def do_lookup() -> int:
             with LoggingContext("c1") as c1:
-                r = yield obj.fn(1)
+                r = await obj.fn(1)
                 self.assertEqual(current_context(), c1)
-            return cast(int, r)
+            return r
 
         def check_result(r: int) -> None:
             self.assertEqual(r, 1)
@@ -292,37 +286,36 @@ class DescriptorTestCase(unittest.TestCase):
         obj = Cls()
 
         # set off a deferred which will do a cache lookup
-        d1 = do_lookup()
+        d1 = defer.ensureDeferred(do_lookup())
         self.assertEqual(current_context(), SENTINEL_CONTEXT)
         d1.addCallback(check_result)
 
         # and another
-        d2 = do_lookup()
+        d2 = defer.ensureDeferred(do_lookup())
         self.assertEqual(current_context(), SENTINEL_CONTEXT)
         d2.addCallback(check_result)
 
         # let the lookup complete
         complete_lookup.callback(None)
 
-        return defer.gatherResults([d1, d2])
+        await d1
+        await d2
 
-    def test_cache_logcontexts_with_exception(self) -> "Deferred[None]":
+    async def test_cache_logcontexts_with_exception(self) -> None:
         """Check that the cache sets and restores logcontexts correctly when
         the lookup function throws an exception"""
 
         class Cls:
             @descriptors.cached()
             def fn(self, arg1: int) -> Deferred:
-                @defer.inlineCallbacks
-                def inner_fn() -> Generator["Deferred[Any]", object, NoReturn]:
+                async def inner_fn() -> NoReturn:
                     # we want this to behave like an asynchronous function
-                    yield run_on_reactor()
+                    await run_on_reactor()
                     raise RelapseError(400, "blah")
 
-                return inner_fn()
+                return defer.ensureDeferred(inner_fn())
 
-        @defer.inlineCallbacks
-        def do_lookup() -> Generator["Deferred[object]", object, None]:
+        async def do_lookup() -> None:
             with LoggingContext("c1") as c1:
                 try:
                     d = obj.fn(1)
@@ -330,7 +323,7 @@ class DescriptorTestCase(unittest.TestCase):
                         current_context(),
                         SENTINEL_CONTEXT,
                     )
-                    yield d
+                    await d
                     self.fail("No exception thrown")
                 except RelapseError:
                     pass
@@ -346,10 +339,9 @@ class DescriptorTestCase(unittest.TestCase):
         d1 = do_lookup()
         self.assertEqual(current_context(), SENTINEL_CONTEXT)
 
-        return d1
+        await d1
 
-    @defer.inlineCallbacks
-    def test_cache_default_args(self) -> Generator["Deferred[Any]", object, None]:
+    async def test_cache_default_args(self) -> None:
         class Cls:
             def __init__(self) -> None:
                 self.mock = mock.Mock()
@@ -361,28 +353,28 @@ class DescriptorTestCase(unittest.TestCase):
         obj = Cls()
 
         obj.mock.return_value = "fish"
-        r = yield obj.fn(1, 2, 3)
+        r = await obj.fn(1, 2, 3)
         self.assertEqual(r, "fish")
         obj.mock.assert_called_once_with(1, 2, 3)
         obj.mock.reset_mock()
 
         # a call with same params shouldn't call the mock again
-        r = yield obj.fn(1, 2)
+        r = await obj.fn(1, 2)
         self.assertEqual(r, "fish")
         obj.mock.assert_not_called()
         obj.mock.reset_mock()
 
         # a call with different params should call the mock again
         obj.mock.return_value = "chips"
-        r = yield obj.fn(2, 3)
+        r = await obj.fn(2, 3)
         self.assertEqual(r, "chips")
         obj.mock.assert_called_once_with(2, 3, 3)
         obj.mock.reset_mock()
 
         # the two values should now be cached
-        r = yield obj.fn(1, 2)
+        r = await obj.fn(1, 2)
         self.assertEqual(r, "fish")
-        r = yield obj.fn(2, 3)
+        r = await obj.fn(2, 3)
         self.assertEqual(r, "chips")
         obj.mock.assert_not_called()
 
@@ -490,7 +482,7 @@ class DescriptorTestCase(unittest.TestCase):
         self.failureResultOf(d1, CancelledError)
         self.assertEqual(d2.result, "123")
 
-    def test_cancel_logcontexts(self) -> None:
+    async def test_cancel_logcontexts(self) -> None:
         """Test that cancellation does not break logcontexts.
 
         * The `CancelledError` must be raised with the correct logcontext.
@@ -527,7 +519,7 @@ class DescriptorTestCase(unittest.TestCase):
         d.cancel()
 
         complete_lookup.callback(None)
-        self.successResultOf(d)
+        await d
         self.assertFalse(
             obj.inner_context_was_finished, "Tried to restart a finished logcontext"
         )
@@ -543,8 +535,7 @@ class CacheDecoratorTestCase(unittest.HomeserverTestCase):
     duplicates would be removed and the two sets of classes combined.
     """
 
-    @defer.inlineCallbacks
-    def test_passthrough(self) -> Generator["Deferred[Any]", object, None]:
+    async def test_passthrough(self) -> None:
         class A:
             @cached()
             def func(self, key: str) -> str:
@@ -552,11 +543,10 @@ class CacheDecoratorTestCase(unittest.HomeserverTestCase):
 
         a = A()
 
-        self.assertEqual((yield a.func("foo")), "foo")
-        self.assertEqual((yield a.func("bar")), "bar")
+        self.assertEqual((await a.func("foo")), "foo")
+        self.assertEqual((await a.func("bar")), "bar")
 
-    @defer.inlineCallbacks
-    def test_hit(self) -> Generator["Deferred[Any]", object, None]:
+    async def test_hit(self) -> None:
         callcount = [0]
 
         class A:
@@ -566,15 +556,14 @@ class CacheDecoratorTestCase(unittest.HomeserverTestCase):
                 return key
 
         a = A()
-        yield a.func("foo")
+        await a.func("foo")
 
         self.assertEqual(callcount[0], 1)
 
-        self.assertEqual((yield a.func("foo")), "foo")
+        self.assertEqual((await a.func("foo")), "foo")
         self.assertEqual(callcount[0], 1)
 
-    @defer.inlineCallbacks
-    def test_invalidate(self) -> Generator["Deferred[Any]", object, None]:
+    async def test_invalidate(self) -> None:
         callcount = [0]
 
         class A:
@@ -584,13 +573,13 @@ class CacheDecoratorTestCase(unittest.HomeserverTestCase):
                 return key
 
         a = A()
-        yield a.func("foo")
+        await a.func("foo")
 
         self.assertEqual(callcount[0], 1)
 
         a.func.invalidate(("foo",))
 
-        yield a.func("foo")
+        await a.func("foo")
 
         self.assertEqual(callcount[0], 2)
 
@@ -602,8 +591,7 @@ class CacheDecoratorTestCase(unittest.HomeserverTestCase):
 
         A().func.invalidate(("what",))
 
-    @defer.inlineCallbacks
-    def test_max_entries(self) -> Generator["Deferred[Any]", object, None]:
+    async def test_max_entries(self) -> None:
         callcount = [0]
 
         class A:
@@ -615,14 +603,14 @@ class CacheDecoratorTestCase(unittest.HomeserverTestCase):
         a = A()
 
         for k in range(12):
-            yield a.func(k)
+            await a.func(k)
 
         self.assertEqual(callcount[0], 12)
 
         # There must have been at least 2 evictions, meaning if we calculate
         # all 12 values again, we must get called at least 2 more times
         for k in range(12):
-            yield a.func(k)
+            await a.func(k)
 
         self.assertTrue(
             callcount[0] >= 14, msg=f"Expected callcount >= 14, got {callcount[0]}"
@@ -631,13 +619,11 @@ class CacheDecoratorTestCase(unittest.HomeserverTestCase):
     def test_prefill(self) -> None:
         callcount = [0]
 
-        d = defer.succeed(123)
-
         class A:
             @cached()
-            def func(self, key: str) -> "Deferred[int]":
+            async def func(self, key: str) -> int:
                 callcount[0] += 1
-                return d
+                return 123
 
         a = A()
 
@@ -646,8 +632,7 @@ class CacheDecoratorTestCase(unittest.HomeserverTestCase):
         self.assertEqual(a.func("foo").result, 456)
         self.assertEqual(callcount[0], 0)
 
-    @defer.inlineCallbacks
-    def test_invalidate_context(self) -> Generator["Deferred[Any]", object, None]:
+    async def test_invalidate_context(self) -> None:
         callcount = [0]
         callcount2 = [0]
 
@@ -658,29 +643,28 @@ class CacheDecoratorTestCase(unittest.HomeserverTestCase):
                 return key
 
             @cached(cache_context=True)
-            def func2(self, key: str, cache_context: _CacheContext) -> "Deferred[str]":
+            def func2(self, key: str, cache_context: _CacheContext) -> Deferred[str]:
                 callcount2[0] += 1
                 return self.func(key, on_invalidate=cache_context.invalidate)
 
         a = A()
-        yield a.func2("foo")
+        await a.func2("foo")
 
         self.assertEqual(callcount[0], 1)
         self.assertEqual(callcount2[0], 1)
 
         a.func.invalidate(("foo",))
-        yield a.func("foo")
+        await a.func("foo")
 
         self.assertEqual(callcount[0], 2)
         self.assertEqual(callcount2[0], 1)
 
-        yield a.func2("foo")
+        await a.func2("foo")
 
         self.assertEqual(callcount[0], 2)
         self.assertEqual(callcount2[0], 2)
 
-    @defer.inlineCallbacks
-    def test_eviction_context(self) -> Generator["Deferred[Any]", object, None]:
+    async def test_eviction_context(self) -> None:
         callcount = [0]
         callcount2 = [0]
 
@@ -691,33 +675,32 @@ class CacheDecoratorTestCase(unittest.HomeserverTestCase):
                 return key
 
             @cached(cache_context=True)
-            def func2(self, key: str, cache_context: _CacheContext) -> "Deferred[str]":
+            def func2(self, key: str, cache_context: _CacheContext) -> Deferred[str]:
                 callcount2[0] += 1
                 return self.func(key, on_invalidate=cache_context.invalidate)
 
         a = A()
-        yield a.func2("foo")
-        yield a.func2("foo2")
+        await a.func2("foo")
+        await a.func2("foo2")
 
         self.assertEqual(callcount[0], 2)
         self.assertEqual(callcount2[0], 2)
 
-        yield a.func2("foo")
+        await a.func2("foo")
         self.assertEqual(callcount[0], 2)
         self.assertEqual(callcount2[0], 2)
 
-        yield a.func("foo3")
+        await a.func("foo3")
 
         self.assertEqual(callcount[0], 3)
         self.assertEqual(callcount2[0], 2)
 
-        yield a.func2("foo")
+        await a.func2("foo")
 
         self.assertEqual(callcount[0], 4)
         self.assertEqual(callcount2[0], 3)
 
-    @defer.inlineCallbacks
-    def test_double_get(self) -> Generator["Deferred[Any]", object, None]:
+    async def test_double_get(self) -> None:
         callcount = [0]
         callcount2 = [0]
 
@@ -728,14 +711,14 @@ class CacheDecoratorTestCase(unittest.HomeserverTestCase):
                 return key
 
             @cached(cache_context=True)
-            def func2(self, key: str, cache_context: _CacheContext) -> "Deferred[str]":
+            def func2(self, key: str, cache_context: _CacheContext) -> Deferred[str]:
                 callcount2[0] += 1
                 return self.func(key, on_invalidate=cache_context.invalidate)
 
         a = A()
         a.func2.cache.cache = mock.Mock(wraps=a.func2.cache.cache)
 
-        yield a.func2("foo")
+        await a.func2("foo")
 
         self.assertEqual(callcount[0], 1)
         self.assertEqual(callcount2[0], 1)
@@ -743,7 +726,7 @@ class CacheDecoratorTestCase(unittest.HomeserverTestCase):
         a.func2.invalidate(("foo",))
         self.assertEqual(a.func2.cache.cache.del_multi.call_count, 1)
 
-        yield a.func2("foo")
+        await a.func2("foo")
         a.func2.invalidate(("foo",))
         self.assertEqual(a.func2.cache.cache.del_multi.call_count, 2)
 
@@ -752,27 +735,26 @@ class CacheDecoratorTestCase(unittest.HomeserverTestCase):
 
         a.func.invalidate(("foo",))
         self.assertEqual(a.func2.cache.cache.del_multi.call_count, 3)
-        yield a.func("foo")
+        await a.func("foo")
 
         self.assertEqual(callcount[0], 2)
         self.assertEqual(callcount2[0], 2)
 
-        yield a.func2("foo")
+        await a.func2("foo")
 
         self.assertEqual(callcount[0], 2)
         self.assertEqual(callcount2[0], 3)
 
 
 class CachedListDescriptorTestCase(unittest.TestCase):
-    @defer.inlineCallbacks
-    def test_cache(self) -> Generator["Deferred[Any]", object, None]:
+    async def test_cache(self) -> None:
         class Cls:
             def __init__(self) -> None:
                 self.mock = mock.Mock()
 
             @descriptors.cached()
-            def fn(self, arg1: int, arg2: int) -> None:
-                pass
+            def fn(self, arg1: int, arg2: int) -> str:
+                raise NotImplementedError()
 
             @descriptors.cachedList(cached_method_name="fn", list_name="args1")
             async def list_fn(
@@ -795,40 +777,40 @@ class CachedListDescriptorTestCase(unittest.TestCase):
             # start the lookup off
             d1 = obj.list_fn([10, 20], 2)
             self.assertEqual(current_context(), SENTINEL_CONTEXT)
-            r = yield d1
+            r_list = await d1
             self.assertEqual(current_context(), c1)
             obj.mock.assert_called_once_with({10, 20}, 2)
-            self.assertEqual(r, {10: "fish", 20: "chips"})
+            self.assertEqual(r_list, {10: "fish", 20: "chips"})
             obj.mock.reset_mock()
 
             # a call with different params should call the mock again
             obj.mock.return_value = {30: "peas"}
-            r = yield obj.list_fn([20, 30], 2)
+            r_list = await obj.list_fn([20, 30], 2)
             obj.mock.assert_called_once_with({30}, 2)
-            self.assertEqual(r, {20: "chips", 30: "peas"})
+            self.assertEqual(r_list, {20: "chips", 30: "peas"})
             obj.mock.reset_mock()
 
             # all the values should now be cached
-            r = yield obj.fn(10, 2)
+            r = await obj.fn(10, 2)
             self.assertEqual(r, "fish")
-            r = yield obj.fn(20, 2)
+            r = await obj.fn(20, 2)
             self.assertEqual(r, "chips")
-            r = yield obj.fn(30, 2)
+            r = await obj.fn(30, 2)
             self.assertEqual(r, "peas")
-            r = yield obj.list_fn([10, 20, 30], 2)
+            r_list = await obj.list_fn([10, 20, 30], 2)
             obj.mock.assert_not_called()
-            self.assertEqual(r, {10: "fish", 20: "chips", 30: "peas"})
+            self.assertEqual(r_list, {10: "fish", 20: "chips", 30: "peas"})
 
             # we should also be able to use a (single-use) iterable, and should
             # deduplicate the keys
             obj.mock.reset_mock()
             obj.mock.return_value = {40: "gravy"}
             iterable = (x for x in [10, 40, 40])
-            r = yield obj.list_fn(iterable, 2)
+            r_list = await obj.list_fn(iterable, 2)
             obj.mock.assert_called_once_with({40}, 2)
-            self.assertEqual(r, {10: "fish", 40: "gravy"})
+            self.assertEqual(r_list, {10: "fish", 40: "gravy"})
 
-    def test_concurrent_lookups(self) -> None:
+    async def test_concurrent_lookups(self) -> None:
         """All concurrent lookups should get the same result"""
 
         class Cls:
@@ -840,7 +822,7 @@ class CachedListDescriptorTestCase(unittest.TestCase):
                 pass
 
             @descriptors.cachedList(cached_method_name="fn", list_name="args1")
-            def list_fn(self, args1: list[int]) -> "Deferred[Mapping[int, str]]":
+            def list_fn(self, args1: list[int]) -> Mapping[int, str]:
                 return self.mock(args1)
 
         obj = Cls()
@@ -866,12 +848,11 @@ class CachedListDescriptorTestCase(unittest.TestCase):
         deferred_result.callback({10: "peas"})
 
         # ... which should give the right result to all the callers
-        self.assertEqual(self.successResultOf(d1), {10: "peas"})
-        self.assertEqual(self.successResultOf(d2), {10: "peas"})
-        self.assertEqual(self.successResultOf(d3), {10: "peas"})
+        self.assertEqual(await d1, {10: "peas"})
+        self.assertEqual(await d2, {10: "peas"})
+        self.assertEqual(await d3, {10: "peas"})
 
-    @defer.inlineCallbacks
-    def test_invalidate(self) -> Generator["Deferred[Any]", object, None]:
+    async def test_invalidate(self) -> None:
         """Make sure that invalidation callbacks are called."""
 
         class Cls:
@@ -894,13 +875,13 @@ class CachedListDescriptorTestCase(unittest.TestCase):
 
         # cache miss
         obj.mock.return_value = {10: "fish", 20: "chips"}
-        r1 = yield obj.list_fn([10, 20], 2, on_invalidate=invalidate0)
+        r1 = await obj.list_fn([10, 20], 2, on_invalidate=invalidate0)
         obj.mock.assert_called_once_with({10, 20}, 2)
         self.assertEqual(r1, {10: "fish", 20: "chips"})
         obj.mock.reset_mock()
 
         # cache hit
-        r2 = yield obj.list_fn([10, 20], 2, on_invalidate=invalidate1)
+        r2 = await obj.list_fn([10, 20], 2, on_invalidate=invalidate1)
         obj.mock.assert_not_called()
         self.assertEqual(r2, {10: "fish", 20: "chips"})
 
@@ -940,7 +921,7 @@ class CachedListDescriptorTestCase(unittest.TestCase):
         self.failureResultOf(d1, CancelledError)
         self.assertEqual(d2.result, {123: "123", 456: "456", 789: "789"})
 
-    def test_cancel_logcontexts(self) -> None:
+    async def test_cancel_logcontexts(self) -> None:
         """Test that cancellation does not break logcontexts.
 
         * The `CancelledError` must be raised with the correct logcontext.
@@ -981,7 +962,7 @@ class CachedListDescriptorTestCase(unittest.TestCase):
         d.cancel()
 
         complete_lookup.callback(None)
-        self.successResultOf(d)
+        await d
         self.assertFalse(
             obj.inner_context_was_finished, "Tried to restart a finished logcontext"
         )

--- a/tests/util/caches/test_descriptors.py
+++ b/tests/util/caches/test_descriptors.py
@@ -189,7 +189,7 @@ class DescriptorTestCase(unittest.TestCase):
 
         class Cls:
             @cached()
-            def fn(self, arg1: int) -> NoReturn:
+            def fn(self, arg1: int) -> None:
                 raise RelapseError(100, "mai spoon iz too big!!1")
 
         obj = Cls()
@@ -422,7 +422,7 @@ class DescriptorTestCase(unittest.TestCase):
 
         class Cls:
             @descriptors.cached(iterable=True)
-            def fn(self, arg1: int) -> NoReturn:
+            def fn(self, arg1: int) -> None:
                 raise RelapseError(100, "mai spoon iz too big!!1")
 
         obj = Cls()

--- a/tests/util/caches/test_response_cache.py
+++ b/tests/util/caches/test_response_cache.py
@@ -49,7 +49,7 @@ class ResponseCacheTestCase(TestCase):
         await self.clock.sleep(1)
         return o
 
-    def test_cache_hit(self) -> None:
+    async def test_cache_hit(self) -> None:
         cache = self.with_cache("keeping_cache", ms=9001)
 
         expected_result = "howdy"
@@ -60,7 +60,7 @@ class ResponseCacheTestCase(TestCase):
 
         self.assertEqual(
             expected_result,
-            self.successResultOf(wrap_d),
+            await wrap_d,
             "initial wrap result should be the same",
         )
 
@@ -70,11 +70,11 @@ class ResponseCacheTestCase(TestCase):
         unexpected.assert_not_called()
         self.assertEqual(
             expected_result,
-            self.successResultOf(wrap2_d),
+            await wrap2_d,
             "cache should still have the result",
         )
 
-    def test_cache_miss(self) -> None:
+    async def test_cache_miss(self) -> None:
         cache = self.with_cache("trashing_cache", ms=0)
 
         expected_result = "howdy"
@@ -85,12 +85,12 @@ class ResponseCacheTestCase(TestCase):
 
         self.assertEqual(
             expected_result,
-            self.successResultOf(wrap_d),
+            await wrap_d,
             "initial wrap result should be the same",
         )
         self.assertCountEqual([], cache.keys(), "cache should not have the result now")
 
-    def test_cache_expire(self) -> None:
+    async def test_cache_expire(self) -> None:
         cache = self.with_cache("short_cache", ms=1000)
 
         expected_result = "howdy"
@@ -99,7 +99,7 @@ class ResponseCacheTestCase(TestCase):
             cache.wrap(0, self.instant_return, expected_result)
         )
 
-        self.assertEqual(expected_result, self.successResultOf(wrap_d))
+        self.assertEqual(expected_result, await wrap_d)
 
         # a second call should return the result without a call to the wrapped function
         unexpected = Mock(spec=())
@@ -107,7 +107,7 @@ class ResponseCacheTestCase(TestCase):
         unexpected.assert_not_called()
         self.assertEqual(
             expected_result,
-            self.successResultOf(wrap2_d),
+            await wrap2_d,
             "cache should still have the result",
         )
 
@@ -115,7 +115,7 @@ class ResponseCacheTestCase(TestCase):
         self.reactor.pump((2,))
         self.assertCountEqual([], cache.keys(), "cache should not have the result now")
 
-    def test_cache_wait_hit(self) -> None:
+    async def test_cache_wait_hit(self) -> None:
         cache = self.with_cache("neutral_cache")
 
         expected_result = "howdy"
@@ -129,9 +129,9 @@ class ResponseCacheTestCase(TestCase):
         # function wakes up, returns result
         self.reactor.pump((2,))
 
-        self.assertEqual(expected_result, self.successResultOf(wrap_d))
+        self.assertEqual(expected_result, await wrap_d)
 
-    def test_cache_wait_expire(self) -> None:
+    async def test_cache_wait_expire(self) -> None:
         cache = self.with_cache("medium_cache", ms=3000)
 
         expected_result = "howdy"
@@ -144,7 +144,7 @@ class ResponseCacheTestCase(TestCase):
         # stop at 1 second to callback cache eviction callLater at that time, then another to set time at 2
         self.reactor.pump((1, 1))
 
-        self.assertEqual(expected_result, self.successResultOf(wrap_d))
+        self.assertEqual(expected_result, await wrap_d)
 
         # a second call should immediately return the result without a call to the
         # wrapped function
@@ -153,7 +153,7 @@ class ResponseCacheTestCase(TestCase):
         unexpected.assert_not_called()
         self.assertEqual(
             expected_result,
-            self.successResultOf(wrap2_d),
+            await wrap2_d,
             "cache should still have the result",
         )
 
@@ -162,7 +162,7 @@ class ResponseCacheTestCase(TestCase):
         self.assertCountEqual([], cache.keys(), "cache should not have the result now")
 
     @parameterized.expand([(True,), (False,)])
-    def test_cache_context_nocache(self, should_cache: bool) -> None:
+    async def test_cache_context_nocache(self, should_cache: bool) -> None:
         """If the callback clears the should_cache bit, the result should not be cached"""
         cache = self.with_cache("medium_cache", ms=3000)
 
@@ -196,8 +196,8 @@ class ResponseCacheTestCase(TestCase):
         self.reactor.advance(1)
 
         # both results should have completed
-        self.assertEqual(expected_result, self.successResultOf(wrap_d))
-        self.assertEqual(expected_result, self.successResultOf(wrap2_d))
+        self.assertEqual(expected_result, await wrap_d)
+        self.assertEqual(expected_result, await wrap2_d)
 
         if should_cache:
             unexpected = Mock(spec=())
@@ -205,7 +205,7 @@ class ResponseCacheTestCase(TestCase):
             unexpected.assert_not_called()
             self.assertEqual(
                 expected_result,
-                self.successResultOf(wrap3_d),
+                await wrap3_d,
                 "cache should still have the result",
             )
 

--- a/tests/util/test_async_helpers.py
+++ b/tests/util/test_async_helpers.py
@@ -111,7 +111,7 @@ class ObservableDeferredTest(TestCase):
         assert results[1] is not None
         self.assertEqual(str(results[1].value), "gah!", "observer 2 errback result")
 
-    def test_cancellation(self) -> None:
+    async def test_cancellation(self) -> None:
         """Test that cancelling an observer does not affect other observers."""
         origin_d: Deferred[int] = Deferred()
         observable = ObservableDeferred(origin_d, consumeErrors=True)
@@ -127,7 +127,8 @@ class ObservableDeferredTest(TestCase):
         # cancel the second observer
         observer2.cancel()
         self.assertFalse(observer1.called)
-        self.failureResultOf(observer2, CancelledError)
+        with self.assertRaises(CancelledError):
+            await observer2
         self.assertFalse(observer3.called)
 
         # other observers resolve as normal
@@ -144,7 +145,7 @@ class TimeoutDeferredTest(TestCase):
     def setUp(self) -> None:
         self.clock = Clock()
 
-    def test_times_out(self) -> None:
+    async def test_times_out(self) -> None:
         """Basic test case that checks that the original deferred is cancelled and that
         the timing-out deferred is errbacked
         """
@@ -163,9 +164,10 @@ class TimeoutDeferredTest(TestCase):
         self.clock.pump((1.0,))
 
         self.assertTrue(cancelled, "deferred was not cancelled by timeout")
-        self.failureResultOf(timing_out_d, defer.TimeoutError)
+        with self.assertRaises(defer.TimeoutError):
+            await timing_out_d
 
-    def test_times_out_when_canceller_throws(self) -> None:
+    async def test_times_out_when_canceller_throws(self) -> None:
         """Test that we have successfully worked around
         https://twistedmatrix.com/trac/ticket/9534"""
 
@@ -179,7 +181,8 @@ class TimeoutDeferredTest(TestCase):
 
         self.clock.pump((1.0,))
 
-        self.failureResultOf(timing_out_d, defer.TimeoutError)
+        with self.assertRaises(defer.TimeoutError):
+            await timing_out_d
 
     async def test_logcontext_is_preserved_on_cancellation(self) -> None:
         blocking_was_cancelled = False
@@ -227,7 +230,7 @@ class _TestException(Exception):
 
 
 class ConcurrentlyExecuteTest(TestCase):
-    def test_limits_runners(self) -> None:
+    async def test_limits_runners(self) -> None:
         """If we have more tasks than runners, we should get the limit of runners"""
         started = 0
         waiters = []
@@ -270,9 +273,9 @@ class ConcurrentlyExecuteTest(TestCase):
         # check everything got done
         self.assertEqual(started, 5)
         self.assertCountEqual(processed, [1, 2, 3, 4, 5])
-        self.successResultOf(d2)
+        await d2
 
-    def test_preserves_stacktraces(self) -> None:
+    async def test_preserves_stacktraces(self) -> None:
         """Test that the stacktrace from an exception thrown in the callback is preserved"""
         d1: Deferred[int] = Deferred()
 
@@ -295,9 +298,9 @@ class ConcurrentlyExecuteTest(TestCase):
 
         d2 = ensureDeferred(caller())
         d1.callback(0)
-        self.successResultOf(d2)
+        await d2
 
-    def test_preserves_stacktraces_on_preformed_failure(self) -> None:
+    async def test_preserves_stacktraces_on_preformed_failure(self) -> None:
         """Test that the stacktrace on a Failure returned by the callback is preserved"""
         d1: Deferred[int] = Deferred()
         f = Failure(_TestException("bah"))
@@ -326,7 +329,7 @@ class ConcurrentlyExecuteTest(TestCase):
 
         d2 = ensureDeferred(caller())
         d1.callback(0)
-        self.successResultOf(d2)
+        await d2
 
 
 @parameterized_class(
@@ -346,7 +349,7 @@ class CancellationWrapperTests(TestCase):
         else:
             raise ValueError(f"Unsupported wrapper type: {self.wrapper}")
 
-    def test_succeed(self) -> None:
+    async def test_succeed(self) -> None:
         """Test that the new `Deferred` receives the result."""
         deferred: Deferred[str] = Deferred()
         wrapper_deferred = self.wrap_deferred(deferred)
@@ -354,9 +357,9 @@ class CancellationWrapperTests(TestCase):
         # Success should propagate through.
         deferred.callback("success")
         self.assertTrue(wrapper_deferred.called)
-        self.assertEqual("success", self.successResultOf(wrapper_deferred))
+        self.assertEqual("success", await wrapper_deferred)
 
-    def test_failure(self) -> None:
+    async def test_failure(self) -> None:
         """Test that the new `Deferred` receives the `Failure`."""
         deferred: Deferred[str] = Deferred()
         wrapper_deferred = self.wrap_deferred(deferred)
@@ -364,14 +367,15 @@ class CancellationWrapperTests(TestCase):
         # Failure should propagate through.
         deferred.errback(ValueError("abc"))
         self.assertTrue(wrapper_deferred.called)
-        self.failureResultOf(wrapper_deferred, ValueError)
+        with self.assertRaises(ValueError):
+            await wrapper_deferred
         self.assertIsNone(deferred.result, "`Failure` was not consumed")
 
 
 class StopCancellationTests(TestCase):
     """Tests for the `stop_cancellation` function."""
 
-    def test_cancellation(self) -> None:
+    async def test_cancellation(self) -> None:
         """Test that cancellation of the new `Deferred` leaves the original running."""
         deferred: Deferred[str] = Deferred()
         wrapper_deferred = stop_cancellation(deferred)
@@ -379,7 +383,8 @@ class StopCancellationTests(TestCase):
         # Cancel the new `Deferred`.
         wrapper_deferred.cancel()
         self.assertTrue(wrapper_deferred.called)
-        self.failureResultOf(wrapper_deferred, CancelledError)
+        with self.assertRaises(CancelledError):
+            await wrapper_deferred
         self.assertFalse(
             deferred.called, "Original `Deferred` was unexpectedly cancelled"
         )
@@ -394,7 +399,7 @@ class StopCancellationTests(TestCase):
 class DelayCancellationTests(TestCase):
     """Tests for the `delay_cancellation` function."""
 
-    def test_deferred_cancellation(self) -> None:
+    async def test_deferred_cancellation(self) -> None:
         """Test that cancellation of the new `Deferred` waits for the original."""
         deferred: Deferred[str] = Deferred()
         wrapper_deferred = delay_cancellation(deferred)
@@ -413,9 +418,10 @@ class DelayCancellationTests(TestCase):
         self.assertIsNone(deferred.result, "`Failure` was not consumed")
 
         # Now that the original `Deferred` has failed, we should get a `CancelledError`.
-        self.failureResultOf(wrapper_deferred, CancelledError)
+        with self.assertRaises(CancelledError):
+            await wrapper_deferred
 
-    def test_coroutine_cancellation(self) -> None:
+    async def test_coroutine_cancellation(self) -> None:
         """Test that cancellation of the new `Deferred` waits for the original."""
         blocking_deferred: Deferred[None] = Deferred()
         completion_deferred: Deferred[None] = Deferred()
@@ -442,9 +448,10 @@ class DelayCancellationTests(TestCase):
         self.assertTrue(completion_deferred.called)
 
         # Now that the original coroutine has failed, we should get a `CancelledError`.
-        self.failureResultOf(wrapper_deferred, CancelledError)
+        with self.assertRaises(CancelledError):
+            await wrapper_deferred
 
-    def test_suppresses_second_cancellation(self) -> None:
+    async def test_suppresses_second_cancellation(self) -> None:
         """Test that a second cancellation is suppressed.
 
         Identical to `test_cancellation` except the new `Deferred` is cancelled twice.
@@ -467,9 +474,10 @@ class DelayCancellationTests(TestCase):
         self.assertIsNone(deferred.result, "`Failure` was not consumed")
 
         # Now that the original `Deferred` has failed, we should get a `CancelledError`.
-        self.failureResultOf(wrapper_deferred, CancelledError)
+        with self.assertRaises(CancelledError):
+            await wrapper_deferred
 
-    def test_propagates_cancelled_error(self) -> None:
+    async def test_propagates_cancelled_error(self) -> None:
         """Test that a `CancelledError` from the original `Deferred` gets propagated."""
         deferred: Deferred[str] = Deferred()
         wrapper_deferred = delay_cancellation(deferred)
@@ -480,9 +488,11 @@ class DelayCancellationTests(TestCase):
 
         # The new `Deferred` should fail with exactly the same `CancelledError`.
         self.assertTrue(wrapper_deferred.called)
-        self.assertIs(cancelled_error, self.failureResultOf(wrapper_deferred).value)
+        with self.assertRaises(CancelledError) as e:
+            await wrapper_deferred
+        self.assertIs(cancelled_error, e.exception)
 
-    def test_preserves_logcontext(self) -> None:
+    async def test_preserves_logcontext(self) -> None:
         """Test that logging contexts are preserved."""
         blocking_d: Deferred[None] = Deferred()
 
@@ -507,7 +517,7 @@ class DelayCancellationTests(TestCase):
         # Now unblock. `outer()` will consume the `CancelledError` and check the
         # logging context.
         blocking_d.callback(None)
-        self.successResultOf(d)
+        await d
 
 
 class AwakenableSleeperTests(TestCase):

--- a/tests/util/test_async_helpers.py
+++ b/tests/util/test_async_helpers.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import traceback
-from collections.abc import Generator
 from typing import NoReturn
 
 from parameterized import parameterized_class
@@ -182,17 +181,16 @@ class TimeoutDeferredTest(TestCase):
 
         self.failureResultOf(timing_out_d, defer.TimeoutError)
 
-    def test_logcontext_is_preserved_on_cancellation(self) -> None:
+    async def test_logcontext_is_preserved_on_cancellation(self) -> None:
         blocking_was_cancelled = False
 
-        @defer.inlineCallbacks
-        def blocking() -> Generator["Deferred[object]", object, None]:
+        async def blocking() -> None:
             nonlocal blocking_was_cancelled
 
             non_completing_d: Deferred = Deferred()
             with PreserveLoggingContext():
                 try:
-                    yield non_completing_d
+                    await non_completing_d
                 except CancelledError:
                     blocking_was_cancelled = True
                     raise
@@ -207,7 +205,7 @@ class TimeoutDeferredTest(TestCase):
                 )
                 return res
 
-            original_deferred = blocking()
+            original_deferred = defer.ensureDeferred(blocking())
             original_deferred.addErrback(errback, "orig")
             timing_out_d = timeout_deferred(original_deferred, 1.0, self.clock)
             self.assertNoResult(timing_out_d)
@@ -219,7 +217,8 @@ class TimeoutDeferredTest(TestCase):
             self.assertTrue(
                 blocking_was_cancelled, "non-completing deferred was not cancelled"
             )
-            self.failureResultOf(timing_out_d, defer.TimeoutError)
+            with self.assertRaises(defer.TimeoutError):
+                await timing_out_d
             self.assertIs(current_context(), context_one)
 
 

--- a/tests/util/test_batching_queue.py
+++ b/tests/util/test_batching_queue.py
@@ -80,7 +80,7 @@ class BatchingQueueTestCase(TestCase):
             "number_in_flight",
         )
 
-    def test_simple(self) -> None:
+    async def test_simple(self) -> None:
         """Tests the basic case of calling `add_to_queue` once and having
         `_process_queue` return.
         """
@@ -107,11 +107,11 @@ class BatchingQueueTestCase(TestCase):
         # Return value of the `_process_queue` should be propagated back.
         self._pending_calls.pop()[1].callback("bar")
 
-        self.assertEqual(self.successResultOf(queue_d), "bar")
+        self.assertEqual(await queue_d, "bar")
 
         self._assert_metrics(queued=0, keys=0, in_flight=0)
 
-    def test_batching(self) -> None:
+    async def test_batching(self) -> None:
         """Test that multiple calls at the same time get batched up into one
         call to `_process_queue`.
         """
@@ -135,11 +135,11 @@ class BatchingQueueTestCase(TestCase):
         # Return value of the `_process_queue` should be propagated back to both.
         self._pending_calls.pop()[1].callback("bar")
 
-        self.assertEqual(self.successResultOf(queue_d1), "bar")
-        self.assertEqual(self.successResultOf(queue_d2), "bar")
+        self.assertEqual(await queue_d1, "bar")
+        self.assertEqual(await queue_d2, "bar")
         self._assert_metrics(queued=0, keys=0, in_flight=0)
 
-    def test_queuing(self) -> None:
+    async def test_queuing(self) -> None:
         """Test that we queue up requests while a `_process_queue` is being
         called.
         """
@@ -168,7 +168,7 @@ class BatchingQueueTestCase(TestCase):
         # first.
         self._pending_calls.pop()[1].callback("bar1")
 
-        self.assertEqual(self.successResultOf(queue_d1), "bar1")
+        self.assertEqual(await queue_d1, "bar1")
         self.assertFalse(queue_d2.called)
         self.assertFalse(queue_d3.called)
         self._assert_metrics(queued=2, keys=1, in_flight=2)
@@ -185,11 +185,11 @@ class BatchingQueueTestCase(TestCase):
         # second.
         self._pending_calls.pop()[1].callback("bar2")
 
-        self.assertEqual(self.successResultOf(queue_d2), "bar2")
-        self.assertEqual(self.successResultOf(queue_d3), "bar2")
+        self.assertEqual(await queue_d2, "bar2")
+        self.assertEqual(await queue_d3, "bar2")
         self._assert_metrics(queued=0, keys=0, in_flight=0)
 
-    def test_different_keys(self) -> None:
+    async def test_different_keys(self) -> None:
         """Test that calls to different keys get processed in parallel."""
 
         self.assertFalse(self._pending_calls)
@@ -216,7 +216,7 @@ class BatchingQueueTestCase(TestCase):
         # first.
         self._pending_calls.pop(0)[1].callback("bar1")
 
-        self.assertEqual(self.successResultOf(queue_d1), "bar1")
+        self.assertEqual(await queue_d1, "bar1")
         self.assertFalse(queue_d2.called)
         self.assertFalse(queue_d3.called)
         self._assert_metrics(queued=1, keys=1, in_flight=2)
@@ -225,7 +225,7 @@ class BatchingQueueTestCase(TestCase):
         # second.
         self._pending_calls.pop()[1].callback("bar2")
 
-        self.assertEqual(self.successResultOf(queue_d2), "bar2")
+        self.assertEqual(await queue_d2, "bar2")
         self.assertFalse(queue_d3.called)
 
         # We should now see a call `_pending_calls` for `foo3`
@@ -239,5 +239,5 @@ class BatchingQueueTestCase(TestCase):
         # third deferred.
         self._pending_calls.pop()[1].callback("bar4")
 
-        self.assertEqual(self.successResultOf(queue_d3), "bar4")
+        self.assertEqual(await queue_d3, "bar4")
         self._assert_metrics(queued=0, keys=0, in_flight=0)

--- a/tests/util/test_file_consumer.py
+++ b/tests/util/test_file_consumer.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import threading
-from collections.abc import Generator
 from io import BytesIO
 from typing import BinaryIO, cast
 from unittest.mock import NonCallableMock
@@ -32,32 +31,30 @@ reactor = cast(IRelapseReactor, _reactor)
 
 
 class FileConsumerTests(unittest.TestCase):
-    @defer.inlineCallbacks
-    def test_pull_consumer(self) -> Generator["defer.Deferred[object]", object, None]:
+    async def test_pull_consumer(self) -> None:
         string_file = BytesIO()
         consumer = BackgroundFileConsumer(string_file, reactor=reactor)
 
         try:
             producer = DummyPullProducer()
 
-            yield producer.register_with_consumer(consumer)
+            await producer.register_with_consumer(consumer)
 
-            yield producer.write_and_wait(b"Foo")
+            await producer.write_and_wait(b"Foo")
 
             self.assertEqual(string_file.getvalue(), b"Foo")
 
-            yield producer.write_and_wait(b"Bar")
+            await producer.write_and_wait(b"Bar")
 
             self.assertEqual(string_file.getvalue(), b"FooBar")
         finally:
             consumer.unregisterProducer()
 
-        yield consumer.wait()  # type: ignore[misc]
+        await consumer.wait()
 
         self.assertTrue(string_file.closed)
 
-    @defer.inlineCallbacks
-    def test_push_consumer(self) -> Generator["defer.Deferred[object]", object, None]:
+    async def test_push_consumer(self) -> None:
         string_file = BlockingBytesWrite()
         consumer = BackgroundFileConsumer(cast(BinaryIO, string_file), reactor=reactor)
 
@@ -67,25 +64,24 @@ class FileConsumerTests(unittest.TestCase):
             consumer.registerProducer(producer, True)
 
             consumer.write(b"Foo")
-            yield string_file.wait_for_n_writes(1)  # type: ignore[misc]
+            await string_file.wait_for_n_writes(1)
 
             self.assertEqual(string_file.buffer, b"Foo")
 
             consumer.write(b"Bar")
-            yield string_file.wait_for_n_writes(2)  # type: ignore[misc]
+            await string_file.wait_for_n_writes(2)
 
             self.assertEqual(string_file.buffer, b"FooBar")
         finally:
             consumer.unregisterProducer()
 
-        yield consumer.wait()  # type: ignore[misc]
+        await consumer.wait()
 
         self.assertTrue(string_file.closed)
 
-    @defer.inlineCallbacks
-    def test_push_producer_feedback(
+    async def test_push_producer_feedback(
         self,
-    ) -> Generator["defer.Deferred[object]", object, None]:
+    ) -> None:
         string_file = BlockingBytesWrite()
         consumer = BackgroundFileConsumer(cast(BinaryIO, string_file), reactor=reactor)
 
@@ -107,14 +103,14 @@ class FileConsumerTests(unittest.TestCase):
 
                 producer.pauseProducing.assert_called_once()
 
-            yield string_file.wait_for_n_writes(number_writes)  # type: ignore[misc]
+            await string_file.wait_for_n_writes(number_writes)
 
-            yield resume_deferred
+            await resume_deferred
             producer.resumeProducing.assert_called_once()
         finally:
             consumer.unregisterProducer()
 
-        yield consumer.wait()  # type: ignore[misc]
+        await consumer.wait()
 
         self.assertTrue(string_file.closed)
 
@@ -176,10 +172,7 @@ class BlockingBytesWrite:
             self._notify_write_deferred = None
         d.callback(None)
 
-    @defer.inlineCallbacks
-    def wait_for_n_writes(
-        self, n: int
-    ) -> Generator["defer.Deferred[object]", object, None]:
+    async def wait_for_n_writes(self, n: int) -> None:
         "Wait for n writes to have happened"
         while True:
             with self.write_lock:
@@ -191,4 +184,4 @@ class BlockingBytesWrite:
 
                 d = self._notify_write_deferred
 
-            yield d
+            await d

--- a/tests/util/test_linearizer.py
+++ b/tests/util/test_linearizer.py
@@ -122,7 +122,7 @@ class LinearizerTestCase(unittest.TestCase):
         unblock2()
         self.assertFalse(linearizer.is_queued(key))
 
-    def test_lots_of_queued_things(self) -> None:
+    async def test_lots_of_queued_things(self) -> None:
         """Tests lots of fast things queued up behind a slow thing.
 
         The stack should *not* explode when the slow thing completes.
@@ -143,7 +143,7 @@ class LinearizerTestCase(unittest.TestCase):
 
         d = defer.ensureDeferred(func(1000))
         unblock()
-        self.successResultOf(d)
+        await d
 
     def test_multiple_entries(self) -> None:
         """Tests a `Linearizer` with a concurrency above 1."""
@@ -186,7 +186,7 @@ class LinearizerTestCase(unittest.TestCase):
         self.assertTrue(acquired_d6)
         unblock6()
 
-    def test_cancellation(self) -> None:
+    async def test_cancellation(self) -> None:
         """Tests cancellation while waiting for a `Linearizer`."""
         linearizer = Linearizer()
 
@@ -207,10 +207,11 @@ class LinearizerTestCase(unittest.TestCase):
         d2.cancel()
 
         unblock1()
-        self.successResultOf(d1)
+        await d1
 
         self.assertTrue(d2.called)
-        self.failureResultOf(d2, CancelledError)
+        with self.assertRaises(CancelledError):
+            await d2
 
         # The third task should continue running.
         self.assertTrue(
@@ -218,9 +219,9 @@ class LinearizerTestCase(unittest.TestCase):
             "Third task did not get the lock after the second task was cancelled",
         )
         unblock3()
-        self.successResultOf(d3)
+        await d3
 
-    def test_cancellation_during_sleep(self) -> None:
+    async def test_cancellation_during_sleep(self) -> None:
         """Tests cancellation during the sleep just after waiting for a `Linearizer`."""
         linearizer = Linearizer()
 
@@ -240,12 +241,13 @@ class LinearizerTestCase(unittest.TestCase):
         # Once the first task completes, cancel the waiting second task while it is
         # sleeping just after acquiring the lock.
         unblock1(pump_reactor=False)
-        self.successResultOf(d1)
+        await d1
         d2.cancel()
         self._pump()
 
         self.assertTrue(d2.called)
-        self.failureResultOf(d2, CancelledError)
+        with self.assertRaises(CancelledError):
+            await d2
 
         # The third task should continue running.
         self.assertTrue(
@@ -253,4 +255,4 @@ class LinearizerTestCase(unittest.TestCase):
             "Third task did not get the lock after the second task was cancelled",
         )
         unblock3()
-        self.successResultOf(d3)
+        await d3

--- a/tests/util/test_logcontext.py
+++ b/tests/util/test_logcontext.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections.abc import Callable, Generator
+from collections.abc import Callable
 from typing import cast
 
 import twisted.python.failure
@@ -45,20 +45,18 @@ class LoggingContextTestCase(unittest.TestCase):
         with LoggingContext("test"):
             self._check_test_key("test")
 
-    @defer.inlineCallbacks
-    def test_sleep(self) -> Generator["defer.Deferred[object]", object, None]:
+    async def test_sleep(self) -> None:
         clock = Clock(reactor)
 
-        @defer.inlineCallbacks
-        def competing_callback() -> Generator["defer.Deferred[object]", object, None]:
+        async def competing_callback() -> None:
             with LoggingContext("competing"):
-                yield clock.sleep(0)
+                await clock.sleep(0)
                 self._check_test_key("competing")
 
-        reactor.callLater(0, competing_callback)
+        reactor.callLater(0, defer.ensureDeferred, competing_callback())
 
         with LoggingContext("one"):
-            yield clock.sleep(0)
+            await clock.sleep(0)
             self._check_test_key("one")
 
     def _test_run_in_background(self, function: Callable[[], object]) -> defer.Deferred:
@@ -102,17 +100,15 @@ class LoggingContextTestCase(unittest.TestCase):
         return d2
 
     def test_run_in_background_with_blocking_fn(self) -> defer.Deferred:
-        @defer.inlineCallbacks
-        def blocking_function() -> Generator["defer.Deferred[object]", object, None]:
-            yield Clock(reactor).sleep(0)
+        async def blocking_function() -> None:
+            await Clock(reactor).sleep(0)
 
         return self._test_run_in_background(blocking_function)
 
     def test_run_in_background_with_non_blocking_fn(self) -> defer.Deferred:
-        @defer.inlineCallbacks
-        def nonblocking_function() -> Generator["defer.Deferred[object]", object, None]:
+        async def nonblocking_function() -> None:
             with PreserveLoggingContext():
-                yield defer.succeed(None)
+                await defer.succeed(None)
 
         return self._test_run_in_background(nonblocking_function)
 
@@ -140,10 +136,7 @@ class LoggingContextTestCase(unittest.TestCase):
 
         return self._test_run_in_background(testfunc)
 
-    @defer.inlineCallbacks
-    def test_make_deferred_yieldable(
-        self,
-    ) -> Generator["defer.Deferred[object]", object, None]:
+    async def test_make_deferred_yieldable(self) -> None:
         # a function which returns an incomplete deferred, but doesn't follow
         # the relapse rules.
         def blocking_function() -> defer.Deferred:
@@ -158,15 +151,12 @@ class LoggingContextTestCase(unittest.TestCase):
             # make sure that the context was reset by make_deferred_yieldable
             self.assertIs(current_context(), sentinel_context)
 
-            yield d1
+            await d1
 
             # now it should be restored
             self._check_test_key("one")
 
-    @defer.inlineCallbacks
-    def test_make_deferred_yieldable_with_chained_deferreds(
-        self,
-    ) -> Generator["defer.Deferred[object]", object, None]:
+    async def test_make_deferred_yieldable_with_chained_deferreds(self) -> None:
         sentinel_context = current_context()
 
         with LoggingContext("one"):
@@ -174,7 +164,7 @@ class LoggingContextTestCase(unittest.TestCase):
             # make sure that the context was reset by make_deferred_yieldable
             self.assertIs(current_context(), sentinel_context)
 
-            yield d1
+            await d1
 
             # now it should be restored
             self._check_test_key("one")

--- a/tests/util/test_ratelimitutils.py
+++ b/tests/util/test_ratelimitutils.py
@@ -25,7 +25,7 @@ from tests.utils import default_config
 
 
 class FederationRateLimiterTestCase(TestCase):
-    def test_ratelimit(self) -> None:
+    async def test_ratelimit(self) -> None:
         """A simple test with the default values"""
         reactor, clock = get_clock()
         rc_config = build_rc_config()
@@ -33,9 +33,9 @@ class FederationRateLimiterTestCase(TestCase):
 
         with ratelimiter.ratelimit("testhost") as d1:
             # shouldn't block
-            self.successResultOf(d1)
+            await d1
 
-    def test_concurrent_limit(self) -> None:
+    async def test_concurrent_limit(self) -> None:
         """Test what happens when we hit the concurrent limit"""
         reactor, clock = get_clock()
         rc_config = build_rc_config({"rc_federation": {"concurrent": 2}})
@@ -43,12 +43,12 @@ class FederationRateLimiterTestCase(TestCase):
 
         with ratelimiter.ratelimit("testhost") as d1:
             # shouldn't block
-            self.successResultOf(d1)
+            await d1
 
             cm2 = ratelimiter.ratelimit("testhost")
             d2 = cm2.__enter__()
             # also shouldn't block
-            self.successResultOf(d2)
+            await d2
 
             cm3 = ratelimiter.ratelimit("testhost")
             d3 = cm3.__enter__()
@@ -58,9 +58,9 @@ class FederationRateLimiterTestCase(TestCase):
             # ... until we complete an earlier request
             cm2.__exit__(None, None, None)
             reactor.advance(0.0)
-            self.successResultOf(d3)
+            await d3
 
-    def test_sleep_limit(self) -> None:
+    async def test_sleep_limit(self) -> None:
         """Test what happens when we hit the sleep limit"""
         reactor, clock = get_clock()
         rc_config = build_rc_config(
@@ -70,11 +70,11 @@ class FederationRateLimiterTestCase(TestCase):
 
         with ratelimiter.ratelimit("testhost") as d1:
             # shouldn't block
-            self.successResultOf(d1)
+            await d1
 
         with ratelimiter.ratelimit("testhost") as d2:
             # nor this
-            self.successResultOf(d2)
+            await d2
 
         with ratelimiter.ratelimit("testhost") as d3:
             # this one should block, though ...
@@ -82,7 +82,7 @@ class FederationRateLimiterTestCase(TestCase):
             sleep_time = _await_resolution(reactor, d3)
             self.assertAlmostEqual(sleep_time, 500, places=3)
 
-    def test_lots_of_queued_things(self) -> None:
+    async def test_lots_of_queued_things(self) -> None:
         """Tests lots of synchronous things queued up behind a slow thing.
 
         The stack should *not* explode when the slow thing completes.
@@ -101,7 +101,7 @@ class FederationRateLimiterTestCase(TestCase):
 
         with ratelimiter.ratelimit("testhost") as d:
             # shouldn't block
-            self.successResultOf(d)
+            await d
 
             async def task() -> None:
                 with ratelimiter.ratelimit("testhost") as d:
@@ -117,7 +117,7 @@ class FederationRateLimiterTestCase(TestCase):
 
         # Wait for all the things to complete.
         reactor.advance(0.0)
-        self.successResultOf(last_task)
+        await last_task
 
 
 def _await_resolution(reactor: ThreadedMemoryReactorClock, d: Deferred) -> float:

--- a/tests/util/test_rwlock.py
+++ b/tests/util/test_rwlock.py
@@ -217,7 +217,7 @@ class ReadWriteLockTestCase(unittest.TestCase):
         d3, _ = self._start_nonblocking_writer(rwlock, key, "write 3 completed")
         self.assertTrue(d3.called)
 
-    def test_cancellation_while_holding_read_lock(self) -> None:
+    async def test_cancellation_while_holding_read_lock(self) -> None:
         """Test cancellation while holding a read lock.
 
         A waiting writer should be given the lock when the reader holding the lock is
@@ -235,15 +235,16 @@ class ReadWriteLockTestCase(unittest.TestCase):
 
         # 3. The reader is cancelled.
         reader_d.cancel()
-        self.failureResultOf(reader_d, CancelledError)
+        with self.assertRaises(CancelledError):
+            await reader_d
 
         # 4. The writer should take the lock and complete.
         self.assertTrue(
             writer_d.called, "Writer is stuck waiting for a cancelled reader"
         )
-        self.assertEqual("write completed", self.successResultOf(writer_d))
+        self.assertEqual("write completed", await writer_d)
 
-    def test_cancellation_while_holding_write_lock(self) -> None:
+    async def test_cancellation_while_holding_write_lock(self) -> None:
         """Test cancellation while holding a write lock.
 
         A waiting reader should be given the lock when the writer holding the lock is
@@ -261,15 +262,16 @@ class ReadWriteLockTestCase(unittest.TestCase):
 
         # 3. The writer is cancelled.
         writer_d.cancel()
-        self.failureResultOf(writer_d, CancelledError)
+        with self.assertRaises(CancelledError):
+            await writer_d
 
         # 4. The reader should take the lock and complete.
         self.assertTrue(
             reader_d.called, "Reader is stuck waiting for a cancelled writer"
         )
-        self.assertEqual("read completed", self.successResultOf(reader_d))
+        self.assertEqual("read completed", await reader_d)
 
-    def test_cancellation_while_waiting_for_read_lock(self) -> None:
+    async def test_cancellation_while_waiting_for_read_lock(self) -> None:
         """Test cancellation while waiting for a read lock.
 
         Tests that cancelling a waiting reader:
@@ -302,7 +304,8 @@ class ReadWriteLockTestCase(unittest.TestCase):
         #    Neither of the writers should be cancelled.
         #    The second writer should still be waiting, but only on the first writer.
         reader_d.cancel()
-        self.failureResultOf(reader_d, CancelledError)
+        with self.assertRaises(CancelledError):
+            await reader_d
         self.assertFalse(writer1_d.called, "First writer was unexpectedly cancelled")
         self.assertFalse(
             writer2_d.called,
@@ -312,15 +315,15 @@ class ReadWriteLockTestCase(unittest.TestCase):
 
         # 5. Unblock the first writer, which should complete.
         unblock_writer1.callback(None)
-        self.assertEqual("write 1 completed", self.successResultOf(writer1_d))
+        self.assertEqual("write 1 completed", await writer1_d)
 
         # 6. The second writer should take the lock and complete.
         self.assertTrue(
             writer2_d.called, "Second writer is stuck waiting for a cancelled reader"
         )
-        self.assertEqual("write 2 completed", self.successResultOf(writer2_d))
+        self.assertEqual("write 2 completed", await writer2_d)
 
-    def test_cancellation_while_waiting_for_write_lock(self) -> None:
+    async def test_cancellation_while_waiting_for_write_lock(self) -> None:
         """Test cancellation while waiting for a write lock.
 
         Tests that cancelling a waiting writer:
@@ -372,7 +375,7 @@ class ReadWriteLockTestCase(unittest.TestCase):
         #    The first writer should be given the lock and block.
         #    The third writer should still be waiting on the second writer.
         unblock_reader.callback(None)
-        self.assertEqual("read completed", self.successResultOf(reader_d))
+        self.assertEqual("read completed", await reader_d)
         self.assertNoResult(writer2_d)
         self.assertFalse(
             writer3_d.called,
@@ -382,14 +385,15 @@ class ReadWriteLockTestCase(unittest.TestCase):
 
         # 7. Unblock the first writer, which should complete.
         unblock_writer1.callback(None)
-        self.assertEqual("write 1 completed", self.successResultOf(writer1_d))
+        self.assertEqual("write 1 completed", await writer1_d)
 
         # 8. The second writer should take the lock and release it immediately, since it
         #    has been cancelled.
-        self.failureResultOf(writer2_d, CancelledError)
+        with self.assertRaises(CancelledError):
+            await writer2_d
 
         # 9. The third writer should take the lock and complete.
         self.assertTrue(
             writer3_d.called, "Third writer is stuck waiting for a cancelled writer"
         )
-        self.assertEqual("write 3 completed", self.successResultOf(writer3_d))
+        self.assertEqual("write 3 completed", await writer3_d)


### PR DESCRIPTION
* `inlineCallbacks` where possible
* `successResultOf`/`failureResultOf` in tests to async/await infrastructure